### PR TITLE
add support for subtitles in the tags description

### DIFF
--- a/src/components/ContentItems/ContentItems.tsx
+++ b/src/components/ContentItems/ContentItems.tsx
@@ -68,7 +68,7 @@ export class TagItem extends React.Component<ContentItemProps> {
             <ShareLink href={'#' + this.props.item.id} />
             {name}
           </H1>
-          {description !== undefined && <Markdown source={description} />}
+          {description !== undefined && <Markdown source={description} raw={false} />}
         </MiddlePanel>
       </Row>
     );

--- a/src/services/MenuBuilder.ts
+++ b/src/services/MenuBuilder.ts
@@ -55,18 +55,18 @@ export class MenuBuilder {
    */
   static addMarkdownItems(
     description: string,
-    parent: GroupModel | undefined = undefined,
+    parent?: GroupModel,
     depth: number = 1,
   ): ContentItemModel[] {
     const renderer = new MarkdownRenderer();
     const headings = renderer.extractHeadings(description || '');
 
-    const mapHeadingsDeep = (parent, items, depth) =>
-      items.map(heading => {
-        const group = new GroupModel('section', heading, parent);
-        group.depth = depth;
+    const mapHeadingsDeep = (headingParent, headingItems, headingDepth) =>
+      headingItems.map(heading => {
+        const group = new GroupModel('section', heading, headingParent);
+        group.depth = headingDepth;
         if (heading.items) {
-          group.items = mapHeadingsDeep(group, heading.items, depth + 1);
+          group.items = mapHeadingsDeep(group, heading.items, headingDepth + 1);
         }
         return group;
       });

--- a/src/services/models/Group.model.ts
+++ b/src/services/models/Group.model.ts
@@ -38,6 +38,7 @@ export class GroupModel implements IMenuItem {
     this.description = tagOrGroup.description || '';
     this.parent = parent;
     this.externalDocs = (tagOrGroup as OpenAPITag).externalDocs;
+    this.items = [];
 
     // groups are active (expanded) by default
     if (this.type === 'group') {


### PR DESCRIPTION
Add support for titles in tags so that they show up in the navigation menu.

![redoc_interactive_demo_and_app_js_ ___sites_github_groupondev_com_ingo_3pip-swagger2](https://user-images.githubusercontent.com/1280277/39276381-a12733e8-489d-11e8-93f8-ef4416e97258.jpg)
