### PR TITLE
Fix #694: Add READ MORE for long description

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 ### Security Definition location
 You can inject Security Definitions widget into any place of your specification `description`. Check out details [here](docs/security-definitions-injection.md).
 
+### "Read More" button
+You can add "Read More" button that allows readers to continue reading more by adding `<!-- READMORE -->` into any place of your specification `description`. Check out details [here](docs/read-more-description.md).
+
 ### Swagger vendor extensions
 ReDoc makes use of the following [vendor extensions](http://swagger.io/specification/#vendorExtensions):
 * [`x-logo`](docs/redoc-vendor-extensions.md#x-logo) - is used to specify API logo

--- a/docs/read-more-description.md
+++ b/docs/read-more-description.md
@@ -1,0 +1,24 @@
+# "Read More"
+
+You can add "Read More" button into your operation `description` by adding a special comment tag `<!-- READMORE -->` (case-sensitive).
+
+```markdown
+paths:
+  '/pet/{petId}/uploadImage':
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      description: |
+        Lorem ipsum dolor sit amet, ne mei mentitum conceptam, no vis saepe commune, idque minimum periculis his et. Sit etiam animal honestatis no, vide interpretaris id quo. Ea odio tincidunt mei, quo id eros persecuti. An quot facete malorum ius, sea ne decore iisque.
+        <!-- READMORE -->
+        Mei at eros assentior, usu ullamcorper mediocritatem no. Augue minimum ea per. Ne cum veniam lobortis sadipscing, ad sit amet docendi. Et delenit iracundia vix, vel ex vero legendos antiopam, et eam modo populo.
+
+        Eu dicat legere quo, facilisi theophrastus eam te. Nisl aeque adipisci cum id, debet reformidans ea mel. Nec ut commodo facilisis abhorreant. Ut homero consul 
+...
+```
+
+
+
+![Read More](https://user-images.githubusercontent.com/127635/48308178-8ba2d580-e5a1-11e8-8cdf-10808d4822e5.gif)
+

--- a/src/common-elements/ReadMore.tsx
+++ b/src/common-elements/ReadMore.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+
+import styled from '../styled-components';
+import {ShelfIcon} from "./shelfs";
+import {Markdown} from "../components";
+
+
+export interface ReadMoreProps {
+  content?: string;
+}
+
+interface ReadMoreState {
+  open: boolean
+}
+
+const ReadMoreWrapper = styled.div`
+  position: relative;
+  overflow: hidden;
+  max-height: ${(props: ReadMoreState) => props.open ? 'auto': '5em'};
+  padding-bottom: ${(props: ReadMoreState) => props.open ? '3em' : '1em'};
+`;
+
+const ReadMoreButtonBackground = styled.div`
+  position: absolute;
+  cursor: pointer;
+  text-align: center;
+  background-image: linear-gradient(to bottom, rgba(255,255,255,0.3), white);
+  width: 100%;
+  bottom: 0;
+  padding: ${(props: ReadMoreState) => props.open ? '0': '2em'};
+`;
+
+const ReadMoreButton = styled.span`
+  background: #999;
+  color: #fff;
+  padding: 0.3em 0.75em;
+  border-radius: 2px;
+`;
+
+export class ReadMore extends React.Component<ReadMoreProps, ReadMoreState> {
+  constructor(props: ReadMoreProps) {
+    super(props);
+    this.state = {
+      open: false
+    };
+  }
+
+  toggle = () => {
+    this.setState(prevState => ({
+      open: !prevState.open
+    }));
+  };
+
+  render() {
+    const { content } = this.props;
+
+    if (!content) {
+      return <ReadMoreWrapper open={false} />
+    }
+
+    return (
+      <ReadMoreWrapper open={this.state.open}>
+        <ReadMoreButtonBackground onClick={this.toggle} open={this.state.open}>
+          <ReadMoreButton>
+            <ShelfIcon
+              size={'1.5em'}
+              color={'white'}
+              direction={this.state.open ? 'up' : 'down'}
+            />
+            {this.state.open ? 'CLOSE' : 'READ MORE'}
+          </ReadMoreButton>
+        </ReadMoreButtonBackground>
+        <Markdown source={content} />
+      </ReadMoreWrapper>
+    );
+  }
+}

--- a/src/common-elements/ReadMore.tsx
+++ b/src/common-elements/ReadMore.tsx
@@ -37,6 +37,11 @@ const ReadMoreButton = styled.span`
   border-radius: 2px;
 `;
 
+const ReadMoreButtonText = styled.span`
+  text-transform: uppercase;
+`;
+
+
 export class ReadMore extends React.Component<ReadMoreProps, ReadMoreState> {
   constructor(props: ReadMoreProps) {
     super(props);
@@ -67,7 +72,9 @@ export class ReadMore extends React.Component<ReadMoreProps, ReadMoreState> {
               color={'white'}
               direction={this.state.open ? 'up' : 'down'}
             />
-            {this.state.open ? 'CLOSE' : 'READ MORE'}
+            <ReadMoreButtonText>
+              {this.state.open ? 'Read More' : 'Close'}
+            </ReadMoreButtonText>
           </ReadMoreButton>
         </ReadMoreButtonBackground>
         <Markdown source={content} />

--- a/src/common-elements/ReadMore.tsx
+++ b/src/common-elements/ReadMore.tsx
@@ -1,22 +1,21 @@
 import * as React from 'react';
 
+import {Markdown} from '../components';
 import styled from '../styled-components';
-import {ShelfIcon} from "./shelfs";
-import {Markdown} from "../components";
-
+import {ShelfIcon} from './shelfs';
 
 export interface ReadMoreProps {
   content?: string;
 }
 
 interface ReadMoreState {
-  open: boolean
+  open: boolean;
 }
 
 const ReadMoreWrapper = styled.div`
   position: relative;
   overflow: hidden;
-  max-height: ${(props: ReadMoreState) => props.open ? 'auto': '5em'};
+  max-height: ${(props: ReadMoreState) => props.open ? 'auto' : '5em'};
   padding-bottom: ${(props: ReadMoreState) => props.open ? '3em' : '1em'};
 `;
 
@@ -27,7 +26,7 @@ const ReadMoreButtonBackground = styled.div`
   background-image: linear-gradient(to bottom, rgba(255,255,255,0.3), white);
   width: 100%;
   bottom: 0;
-  padding: ${(props: ReadMoreState) => props.open ? '0': '2em'};
+  padding: ${(props: ReadMoreState) => props.open ? '0' : '2em'};
 `;
 
 const ReadMoreButton = styled.span`
@@ -41,18 +40,17 @@ const ReadMoreButtonText = styled.span`
   text-transform: uppercase;
 `;
 
-
 export class ReadMore extends React.Component<ReadMoreProps, ReadMoreState> {
   constructor(props: ReadMoreProps) {
     super(props);
     this.state = {
-      open: false
+      open: false,
     };
   }
 
   toggle = () => {
     this.setState(prevState => ({
-      open: !prevState.open
+      open: !prevState.open,
     }));
   };
 
@@ -60,7 +58,7 @@ export class ReadMore extends React.Component<ReadMoreProps, ReadMoreState> {
     const { content } = this.props;
 
     if (!content) {
-      return <ReadMoreWrapper open={false} />
+      return <ReadMoreWrapper open={false} />;
     }
 
     return (

--- a/src/components/Operation/Operation.tsx
+++ b/src/components/Operation/Operation.tsx
@@ -16,10 +16,10 @@ import { RequestSamples } from '../RequestSamples/RequestSamples';
 import { ResponsesList } from '../Responses/ResponsesList';
 import { ResponseSamples } from '../ResponseSamples/ResponseSamples';
 
+import { ReadMore } from '../../common-elements/ReadMore';
 import { OperationModel as OperationType } from '../../services/models';
 import styled from '../../styled-components';
 import { Extensions } from '../Fields/Extensions';
-import { ReadMore } from "../../common-elements/ReadMore";
 
 const OperationRow = styled(Row)`
   backface-visibility: hidden;
@@ -40,12 +40,12 @@ export interface OperationProps {
 
 function splitDescription(description) {
   if (!description) {
-    return ["", ""];
+    return ['', ''];
   } else {
     // str#split split at all occurence of matched string.
     // So "a<!--READMORE-->b<!--READMORE-->c" --> ["a", "<!..>", "b", "<!..>", "c"]
     const [head, ...rest] = description.split(ReadmorePattern);
-    const more = rest.join("");
+    const more = rest.join('');
     return [head, more];
   }
 }

--- a/src/components/Operation/Operation.tsx
+++ b/src/components/Operation/Operation.tsx
@@ -19,6 +19,7 @@ import { ResponseSamples } from '../ResponseSamples/ResponseSamples';
 import { OperationModel as OperationType } from '../../services/models';
 import styled from '../../styled-components';
 import { Extensions } from '../Fields/Extensions';
+import { ReadMore } from "../../common-elements/ReadMore";
 
 const OperationRow = styled(Row)`
   backface-visibility: hidden;
@@ -31,8 +32,22 @@ const Description = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing.unit * 6}px;
 `;
 
+const ReadmorePattern = /<!--\s*READMORE\s*-->/;
+
 export interface OperationProps {
   operation: OperationType;
+}
+
+function splitDescription(description) {
+  if (!description) {
+    return ["", ""];
+  } else {
+    // str#split split at all occurence of matched string.
+    // So "a<!--READMORE-->b<!--READMORE-->c" --> ["a", "<!..>", "b", "<!..>", "c"]
+    const [head, ...rest] = description.split(ReadmorePattern);
+    const more = rest.join("");
+    return [head, more];
+  }
 }
 
 @observer
@@ -43,6 +58,7 @@ export class Operation extends React.Component<OperationProps> {
     const { name: summary, description, deprecated, externalDocs } = operation;
     const hasDescription = !!(description || externalDocs);
 
+    const [headDescription, moreDescription] = splitDescription(description);
     return (
       <OptionsContext.Consumer>
         {options => (
@@ -55,7 +71,8 @@ export class Operation extends React.Component<OperationProps> {
               {options.pathInMiddlePanel && <Endpoint operation={operation} inverted={true} />}
               {hasDescription && (
                 <Description>
-                  {description !== undefined && <Markdown source={description} />}
+                  {description !== undefined && <Markdown source={headDescription} />}
+                  <ReadMore content={moreDescription}/>
                   {externalDocs && <ExternalDocumentation externalDocs={externalDocs} />}
                 </Description>
               )}


### PR DESCRIPTION
# Usage

Add a special comment `<!-- READMORE -->` in `description`.
More content fade in from white, so users can notice there is more content.

```
/foo/{bar}:
  get:
    summary: get Bar from Foo
    description: |
       These lines are visible always.
       <!-- READMORE -->
       These lines are visible only if "Read More" wrapper is open.
       ...very very very long
       <!-- READMORE --> ⬅️ Second and later occurences are treated as normal comment.
```

# Screenshot
![read-more](https://user-images.githubusercontent.com/127635/48308178-8ba2d580-e5a1-11e8-8cdf-10808d4822e5.gif)

# Closes
Closes https://github.com/Rebilly/ReDoc/issues/694