### PR TITLE
Show all the mapping entries

### DIFF
--- a/src/types/open-api.d.ts
+++ b/src/types/open-api.d.ts
@@ -144,6 +144,7 @@ export interface OpenAPISchema {
 export interface OpenAPIDiscriminator {
   propertyName: string;
   mapping?: { [name: string]: string };
+  'x-limitToMapping'?: boolean;
 }
 
 export interface OpenAPIMediaType {


### PR DESCRIPTION
When the discriminator has `mapping` with more than one key pointing to the same ref. Only the last one was shown.
The following example would show only `kitten`, `dog` and `bee` in the dropdown. We'd expect to have all four (i.e. `cat` also!).
```yaml
      discriminator:
        propertyName: petType
        mapping:
          cat: '#/components/schemas/Cat'
          kitten: '#/components/schemas/Cat'
          dog: '#/components/schemas/Dog'
          bee: '#/components/schemas/HoneyBee'
```
In this PR. The dropdown will show all the mappings:
![dropdown_1](https://user-images.githubusercontent.com/270342/50830481-3a685580-1348-11e9-857a-111f5d57c7b4.png)

Another use-case is when the mapping is partial, here the `dog` mapping was removed:
```yaml
      discriminator:
        propertyName: petType
        mapping:
          cat: '#/components/schemas/Cat'
          kitten: '#/components/schemas/Cat'
          bee: '#/components/schemas/HoneyBee'
```
The type `Dog` will be included in addition to the mappings:
![dropdown_2](https://user-images.githubusercontent.com/270342/50830505-48b67180-1348-11e9-9470-8e201d778482.png)

The third use-case is an exhaustive mapping, in that case we'd like to ignore non-mapping child classes. I've added a new extension `x-limitToMapping` of type boolean. When used, it excludes the class `Dog` in the following case:
```yaml
      discriminator:
        propertyName: petType
        x-limitToMapping: true
        mapping:
          cat: '#/components/schemas/Cat'
          kitten: '#/components/schemas/Cat'
          bee: '#/components/schemas/HoneyBee'
```
will yield the following result:
![dropdown_3](https://user-images.githubusercontent.com/270342/50830632-a1860a00-1348-11e9-9322-a29bf60a102c.png)
