### PR TITLE
Display each security requirement on a new line

### DIFF
--- a/src/components/SecurityRequirement/SecurityRequirement.tsx
+++ b/src/components/SecurityRequirement/SecurityRequirement.tsx
@@ -38,6 +38,8 @@ const SecurityRequirementAndWrap = styled.span`
 `;
 
 const SecurityRequirementOrWrap = styled.span`
+  display: block;
+
   &:before {
     content: '( ';
     font-weight: bold;


### PR DESCRIPTION
This PR just makes security requirements block level elements so that they read nicer, particularly when there are several alternatives available.

Current display:
![image](https://user-images.githubusercontent.com/7688837/54619388-66950680-4a5c-11e9-92d6-70ae9d5416aa.png)


with this PR becomes:
![image](https://user-images.githubusercontent.com/7688837/54619347-53823680-4a5c-11e9-82a9-383cec530f9a.png)
