### PR TITLE
feat: Custom Extension Components

### DIFF
--- a/src/components/Fields/Extensions.tsx
+++ b/src/components/Fields/Extensions.tsx
@@ -4,13 +4,20 @@ import { ExtensionValue, FieldLabel } from '../../common-elements/fields';
 
 import styled from '../../styled-components';
 
-import { OptionsContext } from '../OptionsProvider';
-
+import { AppStore } from '../../services';
 import { StyledMarkdownBlock } from '../Markdown/styled.elements';
+import { OptionsContext } from '../OptionsProvider';
+import { StoreConsumer } from '../StoreBuilder';
 
 const Extension = styled(StyledMarkdownBlock)`
   margin: 2px 0;
 `;
+
+export interface ExtensionComponentMeta {
+  component: React.ComponentType;
+  propsSelector: (store?: AppStore) => any;
+  props?: object;
+}
 
 export interface ExtensionsProps {
   extensions: {
@@ -19,6 +26,39 @@ export interface ExtensionsProps {
 }
 
 export class Extensions extends React.PureComponent<ExtensionsProps> {
+  renderExtensionComponent(key: string, meta: ExtensionComponentMeta) {
+    const exts = this.props.extensions;
+
+    return (
+      <StoreConsumer>
+        {store => (
+          <meta.component
+            {...{
+              ...meta.props,
+              ...meta.propsSelector(store),
+              ...{
+                [key]: exts[key],
+              },
+            }}
+          />
+        )}
+      </StoreConsumer>
+    );
+  }
+
+  renderSimpleExtension(key: string) {
+    const exts = this.props.extensions;
+
+    return (
+      <>
+        <FieldLabel> {key.substring(2)}: </FieldLabel>{' '}
+        <ExtensionValue>
+          {typeof exts[key] === 'string' ? exts[key] : JSON.stringify(exts[key])}
+        </ExtensionValue>
+      </>
+    );
+  }
+
   render() {
     const exts = this.props.extensions;
     return (
@@ -28,10 +68,9 @@ export class Extensions extends React.PureComponent<ExtensionsProps> {
             {options.showExtensions &&
               Object.keys(exts).map(key => (
                 <Extension key={key}>
-                  <FieldLabel> {key.substring(2)}: </FieldLabel>{' '}
-                  <ExtensionValue>
-                    {typeof exts[key] === 'string' ? exts[key] : JSON.stringify(exts[key])}
-                  </ExtensionValue>
+                  {options.extensionsComponents[key]
+                    ? this.renderExtensionComponent(key, options.extensionsComponents[key])
+                    : this.renderSimpleExtension(key)}
                 </Extension>
               ))}
           </>

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -1,7 +1,7 @@
 import defaultTheme, { ResolvedThemeInterface, resolveTheme, ThemeInterface } from '../theme';
 import { querySelector } from '../utils/dom';
 import { isArray, isNumeric, mergeObjects } from '../utils/helpers';
-
+import { ExtensionComponentMeta } from '../components/Fields/Extensions';
 import { setRedocLabels } from './Labels';
 import { SideNavStyleEnum } from './types';
 import type { LabelsConfigRaw, MDXComponentMeta } from './types';
@@ -30,6 +30,7 @@ export interface RedocRawOptions {
   hideSingleRequestSampleTab?: boolean | string;
   menuToggle?: boolean | string;
   jsonSampleExpandLevel?: number | string | 'all';
+  extensionsComponents?: Record<string, ExtensionComponentMeta>;
   hideSchemaTitles?: boolean | string;
   simpleOneOfTypeLabel?: boolean | string;
   payloadSampleIdx?: number;
@@ -234,6 +235,7 @@ export class RedocNormalizedOptions {
   menuToggle: boolean;
   jsonSampleExpandLevel: number;
   enumSkipQuotes: boolean;
+  extensionsComponents: Record<string, ExtensionComponentMeta>;
   hideSchemaTitles: boolean;
   simpleOneOfTypeLabel: boolean;
   payloadSampleIdx: number;
@@ -321,6 +323,7 @@ export class RedocNormalizedOptions {
     this.allowedMdComponents = raw.allowedMdComponents || {};
 
     this.expandDefaultServerVariables = argValueToBoolean(raw.expandDefaultServerVariables);
+    this.extensionsComponents = raw.extensionsComponents || {};
     this.maxDisplayedEnumValues = argValueToNumber(raw.maxDisplayedEnumValues);
     const ignoreNamedSchemas = isArray(raw.ignoreNamedSchemas)
       ? raw.ignoreNamedSchemas


### PR DESCRIPTION
### Custom Element for openapi extensions

Inspired by Extended Markdown Components feature, add the ability to customize how an extension should be rendered. Backwards compatible.

Usage:
```yaml
openapi: 3.0.0
paths:
  /pet:
    post:
      x-custom:  # or whatever the extension lives
        - foo
        - bar
```

```ts
const options: RedocRawOptions = {
  showExtensions: true,
  extensionsComponents: {
    'x-custom': {
      component: ExtensionCustomComponent,
      propsSelector: (store: AppStore) => store.spec.parser.spec,
      props: { defined: true },
    },
  },
}

type Props = OpenAPISpec & { defined: boolean } & {
  'x-custom': any
};
class ExtensionCustomComponent extends React.PureComponent<Props> {
  render() { 
    // this.props['x-custom'] === ['foo', 'bar']
    // this.props.defined === true
    // this.props also has what propsSelector returns, in this case, all the spec properties
  }
}
```
