### PR TITLE
CLI: Bundle or Serve with custom ReDoc source, Response Sample tab custom title

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "redoc-cli",
+  "name": "redoc-cli-kb",
   "version": "0.8.4",
-  "description": "ReDoc's Command Line Interface",
+  "description": "ReDoc's Command Line Interface (fork)",
   "main": "index.js",
   "bin": "index.js",
-  "repository": "https://github.com/Redocly/redoc",
-  "author": "Roman Hotsiy <gotsijroman@gmail.com>",
+  "repository": "https://github.com/konradbartecki/redoc",
+  "author": "Konrad Bartecki <konrad@bartecki.me>",
   "license": "MIT",
   "dependencies": {
     "chokidar": "^2.0.4",

--- a/src/components/ResponseSamples/ResponseSamples.tsx
+++ b/src/components/ResponseSamples/ResponseSamples.tsx
@@ -29,7 +29,7 @@ export class ResponseSamples extends React.Component<ResponseSamplesProps> {
             <TabList>
               {responses.map(response => (
                 <Tab className={'tab-' + response.type} key={response.code}>
-                  {response.code}
+                  {response.summary ? response.summary : response.code}
                 </Tab>
               ))}
             </TabList>

--- a/src/components/Responses/ResponseTitle.tsx
+++ b/src/components/Responses/ResponseTitle.tsx
@@ -26,7 +26,7 @@ export class ResponseTitle extends React.PureComponent<ResponseTitleProps> {
             float={'left'}
           />
         )}
-        <strong>{code} </strong>
+        {/* <strong>{code} </strong> */}
         <Markdown compact={true} inline={true} source={title} />
       </div>
     );


### PR DESCRIPTION
Hello I have added following changes that may be helpful.
- Ability to specify custom ReDoc source that will be bundled with `--customScript .\redoc.standalone.js` option.
- Ability to override Response Sample tab title from status code to text.
![image](https://user-images.githubusercontent.com/3373490/59114690-01a8c880-8948-11e9-8110-ac9a0a7139d2.png)
