### PR TITLE
Add missing content type header on compressed responses of /

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -156,7 +156,9 @@ async function serve(port: number, pathToSpec: string, options: Options = {}) {
         },
       );
     } else if (request.url === '/') {
-      respondWithGzip(pageHTML, request, response);
+      respondWithGzip(pageHTML, request, response, {
+        'Content-Type': 'text/html',
+      });
     } else if (request.url === '/spec.json') {
       const specStr = JSON.stringify(spec, null, 2);
       respondWithGzip(specStr, request, response, {


### PR DESCRIPTION
I'm hosting an instance of redoc behind an HTTPs proxy at tugboat.qa. If a browser requests a compressed response, redoc-cli doesn't emit a `Content-Type` header. The HTTPs proxy is then inferring a `Content-Type` of `application/octet`, causing browsers to download the page instead of displaying it.

This PR sets the content type for `/`.