### PR TITLE
Fix non-recursive allOf schemas being marked as recursive

### DIFF
--- a/src/services/__tests__/OpenAPIParser.test.ts
+++ b/src/services/__tests__/OpenAPIParser.test.ts
@@ -12,5 +12,13 @@ describe('Models', () => {
       parser = new OpenAPIParser(spec, undefined, opts);
       expect(parser.mergeAllOf(spec.components.schemas.test)).toMatchSnapshot();
     });
+
+    test('should not mark as circular when multiple schemas in allOf use the same ref', () => {
+      const spec = require('./fixtures/allOfCircular.json');
+      parser = new OpenAPIParser(spec, undefined, opts);
+      expect(
+        parser.mergeAllOf(spec.components.schemas.test).properties.object['x-circular-ref'],
+      ).toEqual(undefined);
+    });
   });
 });

--- a/src/services/__tests__/fixtures/allOfCircular.json
+++ b/src/services/__tests__/fixtures/allOfCircular.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "Foo"
+  },
+  "components": {
+    "schemas": {
+      "BaseObj": {
+        "type": "object",
+        "properties": {
+          "test": {
+            "type": "string"
+          }
+        }
+      },
+      "ExtendedObj": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseObj"
+          },
+          {
+            "description": "Extended"
+          }
+        ]
+      },
+      "Base": {
+        "type": "object",
+        "properties": {
+          "object": {
+            "$ref": "#/components/schemas/BaseObj"
+          }
+        }
+      },
+      "test": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Base"
+          },
+          {
+            "properties": {
+              "object": {
+                "$ref": "#/components/schemas/ExtendedObj"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #490 and similar problems with allOf schemas marked as recursive. The bug is fixed by discarding changes to the `RefCounter` in `OpenAPIParser` after parsing each schema within an allOf schema. This causes each schema in the allOf to be parsed independently of each other.