### PR TITLE
Revert expanding default server variables

### DIFF
--- a/src/components/Endpoint/Endpoint.tsx
+++ b/src/components/Endpoint/Endpoint.tsx
@@ -5,7 +5,7 @@ import { Markdown } from '../Markdown/Markdown';
 import { OptionsContext } from '../OptionsProvider';
 import { SelectOnClick } from '../SelectOnClick/SelectOnClick';
 
-import { expandDefaultServerVariables, getBasePath } from '../../utils';
+import { getBasePath } from '../../utils';
 import {
   EndpointInfo,
   HttpVerb,
@@ -61,16 +61,15 @@ export class Endpoint extends React.Component<EndpointProps, EndpointState> {
             </EndpointInfo>
             <ServersOverlay expanded={expanded}>
               {operation.servers.map(server => {
-                const normalizedUrl = expandDefaultServerVariables(server.url, server.variables);
                 return (
-                  <ServerItem key={normalizedUrl}>
+                  <ServerItem key={server.url}>
                     <Markdown source={server.description || ''} compact={true} />
                     <SelectOnClick>
                       <ServerUrl>
                         <span>
                           {hideHostname || options.hideHostname
-                            ? getBasePath(normalizedUrl)
-                            : normalizedUrl}
+                            ? getBasePath(server.url)
+                            : server.url}
                         </span>
                         {operation.path}
                       </ServerUrl>

--- a/src/utils/__tests__/openapi.test.ts
+++ b/src/utils/__tests__/openapi.test.ts
@@ -13,7 +13,6 @@ import {
 
 import { FieldModel, OpenAPIParser, RedocNormalizedOptions } from '../../services';
 import { OpenAPIParameter, OpenAPIParameterLocation, OpenAPIParameterStyle } from '../../types';
-import { expandDefaultServerVariables } from '../openapi';
 
 describe('Utils', () => {
   describe('openapi getStatusCode', () => {
@@ -294,39 +293,6 @@ describe('Utils', () => {
       ]);
       expect(res).toEqual([{ url: 'https://base.com/sandbox/test', description: 'test' }]);
     });
-
-    it('should expand variables', () => {
-      const servers = normalizeServers('', [
-        {
-          url: 'http://{host}{basePath}',
-          variables: {
-            host: {
-              default: '127.0.0.1',
-            },
-            basePath: {
-              default: '/path/to/endpoint',
-            },
-          },
-        },
-        {
-          url: 'http://127.0.0.2:{port}',
-          variables: {},
-        },
-        {
-          url: 'http://127.0.0.3',
-        },
-      ]);
-
-      expect(expandDefaultServerVariables(servers[0].url, servers[0].variables)).toEqual(
-        'http://127.0.0.1/path/to/endpoint',
-      );
-      expect(expandDefaultServerVariables(servers[1].url, servers[1].variables)).toEqual(
-        'http://127.0.0.2:{port}',
-      );
-      expect(expandDefaultServerVariables(servers[2].url, servers[2].variables)).toEqual(
-        'http://127.0.0.3',
-      );
-    });
   });
 
   describe('openapi humanizeConstraints', () => {
@@ -550,7 +516,9 @@ describe('Utils', () => {
         locationTestGroup.cases.forEach(valueTypeTestGroup => {
           describe(valueTypeTestGroup.description, () => {
             valueTypeTestGroup.cases.forEach(testCase => {
-              it(`should serialize correctly when style is ${testCase.style} and explode is ${testCase.explode}`, () => {
+              it(`should serialize correctly when style is ${testCase.style} and explode is ${
+                testCase.explode
+              }`, () => {
                 const parameter: OpenAPIParameter = {
                   name: locationTestGroup.name,
                   in: locationTestGroup.location,

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -487,13 +487,6 @@ export function mergeSimilarMediaTypes(types: Dict<OpenAPIMediaType>): Dict<Open
   return mergedTypes;
 }
 
-export function expandDefaultServerVariables(url: string, variables: object = {}) {
-  return url.replace(
-    /(?:{)(\w+)(?:})/g,
-    (match, name) => (variables[name] && variables[name].default) || match,
-  );
-}
-
 export function normalizeServers(
   specUrl: string | undefined,
   servers: OpenAPIServer[],


### PR DESCRIPTION
Servers are just displayed in Redoc and are not used to make calls so expanding variables may confuse you that the server doesn't have variables:

e.g.:

`https://{stage}.example.com` - makes it clear that the stage can be configurable

vs  `https://prod.example.com` - you have no way to learn about other stages and that they are configurable