### PR TITLE
fix: use url template dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "stickyfill": "^1.1.1",
     "swagger2openapi": "^5.3.1",
     "tslib": "^1.10.0",
-    "uri-template-lite": "^19.4.0"
+    "url-template": "^2.0.8"
   },
   "bundlesize": [
     {

--- a/src/utils/__tests__/openapi.test.ts
+++ b/src/utils/__tests__/openapi.test.ts
@@ -404,7 +404,7 @@ describe('Utils', () => {
               { style: 'simple', explode: false, expected: 'role,admin,firstName,Alex' },
               { style: 'simple', explode: true, expected: 'role=admin,firstName=Alex' },
               { style: 'label', explode: false, expected: '.role,admin,firstName,Alex' },
-              { style: 'label', explode: true, expected: '.role=admin,firstName=Alex' },
+              { style: 'label', explode: true, expected: '.role=admin.firstName=Alex' },
               { style: 'matrix', explode: false, expected: ';id=role,admin,firstName,Alex' },
               { style: 'matrix', explode: true, expected: ';role=admin;firstName=Alex' },
             ],
@@ -516,9 +516,7 @@ describe('Utils', () => {
         locationTestGroup.cases.forEach(valueTypeTestGroup => {
           describe(valueTypeTestGroup.description, () => {
             valueTypeTestGroup.cases.forEach(testCase => {
-              it(`should serialize correctly when style is ${testCase.style} and explode is ${
-                testCase.explode
-              }`, () => {
+              it(`should serialize correctly when style is ${testCase.style} and explode is ${testCase.explode}`, () => {
                 const parameter: OpenAPIParameter = {
                   name: locationTestGroup.name,
                   in: locationTestGroup.location,

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -1,5 +1,5 @@
 import { dirname } from 'path';
-import { URI } from 'uri-template-lite';
+const URLtemplate = require('url-template');
 
 import { OpenAPIParser } from '../services/OpenAPIParser';
 import {
@@ -168,7 +168,7 @@ function serializeFormValue(name: string, explode: boolean, value: any) {
   // e.g. URI.template doesn't parse names with hypen (-) which are valid query param names
   const safeName = '__redoc_param_name__';
   const suffix = explode ? '*' : '';
-  const template = new URI.Template(`{?${safeName}${suffix}}`);
+  const template = URLtemplate.parse(`{?${safeName}${suffix}}`);
   return template
     .expand({ [safeName]: value })
     .substring(1)
@@ -227,7 +227,7 @@ function serializePathParameter(
   // Use RFC6570 safe name ([a-zA-Z0-9_]) and replace with our name later
   // e.g. URI.template doesn't parse names with hypen (-) which are valid query param names
   const safeName = '__redoc_param_name__';
-  const template = new URI.Template(`{${prefix}${safeName}${suffix}}`);
+  const template = URLtemplate.parse(`{${prefix}${safeName}${suffix}}`);
 
   return template.expand({ [safeName]: value }).replace(/__redoc_param_name__/g, name);
 }
@@ -285,7 +285,7 @@ function serializeHeaderParameter(
 
       // name is not important here, so use RFC6570 safe name ([a-zA-Z0-9_])
       const name = '__redoc_param_name__';
-      const template = new URI.Template(`{${name}${suffix}}`);
+      const template = URLtemplate.parse(`{${name}${suffix}}`);
       return decodeURIComponent(template.expand({ [name]: value }));
     default:
       console.warn('Unexpected style for header: ' + style);


### PR DESCRIPTION
We propose to use [`url-template`](https://www.npmjs.com/package/url-template) instead of [`uri-template-lite` ](https://www.npmjs.com/package/uri-template-lite). `uri-template-lite` seems to be vulnerable for a XSS attack as stated in #1007. I agree this dependency is less maintained then `uri-template-lite`. However, as the approach of this dependency is to generate code on runtime, probably to speed it up (therefore the '-lite'), we do not consider it 'safe'. 

Also corrected a test that was not conform the [spec](https://tools.ietf.org/html/rfc6570#section-3.2.5), and detected by the new `url-template` dependency:
```
X{.list*}          X.red.green.blue
```
Therefore, the following test does not seems to be correct:
```
{ style: 'label', explode: true, expected: '.role=admin,firstName=Alex' },
```
should be:
```
{ style: 'label', explode: true, expected: '.role=admin.firstName=Alex' },
```
If you have any questions, let me know. We do like Redoc, but we have to comply to serious security policies.