### PR TITLE
Correct typo of expolde to explode

### DIFF
--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -263,7 +263,7 @@ function serializeQueryParameter(
       return `${name}=${value.join('|')}`;
     case 'deepObject':
       if (!explode || Array.isArray(value) || typeof value !== 'object') {
-        console.warn('The style deepObject is only applicable for objects with expolde=true');
+        console.warn('The style deepObject is only applicable for objects with explode=true');
         return '';
       }
 


### PR DESCRIPTION
This PR simply corrects a typo that happens when the console warns about deepObjects being used incorrectly