### PR TITLE
Add core-js as peer dependency in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ For npm:
 
 Install peer dependencies required by ReDoc if you don't have them installed already:
 
-    npm i react react-dom mobx@^4.2.0 styled-components
+    npm i react react-dom mobx@^4.2.0 styled-components core-js
 
 Import `RedocStandalone` component from 'redoc' module:
 


### PR DESCRIPTION
Since the redoc react component will not work without core-js, it should be added to the docs

Ref #997