### PR TITLE
added support for JSON string value for --options CLI argument

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -64,14 +64,12 @@ YargsParser.command(
     return yargs;
   },
   async argv => {
-    const redocOptions = getRedocOptions(argv.options);
-
     const config: Options = {
       ssr: argv.ssr as boolean,
       watch: argv.watch as boolean,
       templateFileName: argv.template as string,
       templateOptions: argv.templateOptions || {},
-      redocOptions,
+      redocOptions: getObjectOrJSON(argv.options),
     };
 
     console.log(config);
@@ -120,8 +118,6 @@ YargsParser.command(
       return yargs;
     },
     async (argv: any) => {
-      const redocOptions = getRedocOptions(argv.options);
-
       const config = {
         ssr: true,
         output: argv.o as string,
@@ -130,7 +126,7 @@ YargsParser.command(
         disableGoogleFont: argv.disableGoogleFont as boolean,
         templateFileName: argv.template as string,
         templateOptions: argv.templateOptions || {},
-        redocOptions,
+        redocOptions: getObjectOrJSON(argv.options),
       };
 
       try {
@@ -360,7 +356,7 @@ function handleError(error: Error) {
   process.exit(1);
 }
 
-function getRedocOptions(options) {
+function getObjectOrJSON(options) {
   return options && typeof options === 'string' 
         ? JSON.parse(options) : options
         ? options

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -64,13 +64,17 @@ YargsParser.command(
     return yargs;
   },
   async argv => {
+    const redocOptions = getRedocOptions(argv.options);
+
     const config: Options = {
       ssr: argv.ssr as boolean,
       watch: argv.watch as boolean,
       templateFileName: argv.template as string,
       templateOptions: argv.templateOptions || {},
-      redocOptions: argv.options || {},
+      redocOptions,
     };
+
+    console.log(config);
 
     try {
       await serve(argv.port as number, argv.spec as string, config);
@@ -116,6 +120,8 @@ YargsParser.command(
       return yargs;
     },
     async (argv: any) => {
+      const redocOptions = getRedocOptions(argv.options);
+
       const config = {
         ssr: true,
         output: argv.o as string,
@@ -124,7 +130,7 @@ YargsParser.command(
         disableGoogleFont: argv.disableGoogleFont as boolean,
         templateFileName: argv.template as string,
         templateOptions: argv.templateOptions || {},
-        redocOptions: argv.options || {},
+        redocOptions,
       };
 
       try {
@@ -352,4 +358,11 @@ function escapeUnicode(str) {
 function handleError(error: Error) {
   console.error(error.stack);
   process.exit(1);
+}
+
+function getRedocOptions(options) {
+  return options && typeof options === 'string' 
+        ? JSON.parse(options) : options
+        ? options
+        : {};
 }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -357,8 +357,13 @@ function handleError(error: Error) {
 }
 
 function getObjectOrJSON(options) {
-  return options && typeof options === 'string' 
-        ? JSON.parse(options) : options
-        ? options
-        : {};
+  try {
+    return options && typeof options === 'string' 
+    ? JSON.parse(options) : options
+    ? options
+    : {};
+  } catch (e) {
+    console.log(`Encountered error:\n${options}\nis not a valid JSON.`);
+    handleError(e);
+  }
 }


### PR DESCRIPTION
This PR addresses the #797 issue and allows to pass JSON object for cli options as string for the redoc-cli. For example:

```
redoc-cli serve --options='{"theme":{"colors":{"primary":{"main":"orange"}}}}' petstore.yaml
```

will work as well as 

```
node index.js serve --options.theme.colors.primary.main='orange' petstore.yaml
```
