### PR TITLE
Fix item type pluralization for nested arrays

### DIFF
--- a/src/utils/__tests__/openapi.test.ts
+++ b/src/utils/__tests__/openapi.test.ts
@@ -381,6 +381,14 @@ describe('Utils', () => {
         'objects (Pet) or numbers <int64>',
       );
     });
+
+    it('should not pluralize display types that are already pluralized', () => {
+      expect(pluralizeType('strings')).toEqual('strings');
+      expect(pluralizeType('objects (Pet)')).toEqual('objects (Pet)');
+      expect(pluralizeType('strings <email>')).toEqual('strings <email>');
+      expect(pluralizeType('objects or strings')).toEqual('objects or strings');
+      expect(pluralizeType('objects (Pet) or numbers <int64>')).toEqual('objects (Pet) or numbers <int64>');
+    });
   });
 
   describe('openapi serializeParameter', () => {

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -579,6 +579,6 @@ export function extractExtensions(obj: object, showExtensions: string[] | true):
 export function pluralizeType(displayType: string): string {
   return displayType
     .split(' or ')
-    .map(type => type.replace(/^(string|object|number|integer|array|boolean)( ?.*)/, '$1s$2'))
+    .map(type => type.replace(/^(string|object|number|integer|array|boolean)s?( ?.*)/, '$1s$2'))
     .join(' or ');
 }


### PR DESCRIPTION
Hello,

I had a look at #1053 and came up with an adjustment such that the innermost item type of a nested array won't be be made plural more than once.

Here's an example output as a result of the change:

![image](https://user-images.githubusercontent.com/43751307/66486825-e6a8b980-eadd-11e9-8045-c3b1f6797575.png)

Though this degree of nesting seems fairly contrived, some might feel the full display type still looks strange.

I guess an alternative would be to facilitate expansion of members that are arrays, kind of like the following (i.e. `Array of arrays` instead):

![image](https://user-images.githubusercontent.com/43751307/66487555-16a48c80-eadf-11e9-8a70-6aae8a4f218c.png)

However, the above would require a lot more effort from the look of it.