### PR TITLE
Show examples in objects.

### DIFF
--- a/src/components/Schema/ObjectSchema.tsx
+++ b/src/components/Schema/ObjectSchema.tsx
@@ -63,7 +63,7 @@ export class ObjectSchema extends React.Component<ObjectSchemaProps> {
                   undefined
                 }
                 className={field.expanded ? 'expanded' : undefined}
-                showExamples={false}
+                showExamples={true}
                 skipReadOnly={this.props.skipReadOnly}
                 skipWriteOnly={this.props.skipWriteOnly}
                 showTitle={this.props.showTitle}

--- a/src/components/__tests__/__snapshots__/DiscriminatorDropdown.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DiscriminatorDropdown.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`Components SchemaView discriminator should correctly render discriminat
       }
       isLast={false}
       key="packSize"
-      showExamples={false}
+      showExamples={true}
     />
     <Field
       field={
@@ -102,7 +102,7 @@ exports[`Components SchemaView discriminator should correctly render discriminat
       isLast={true}
       key="type"
       renderDiscriminatorSwitch={[Function]}
-      showExamples={false}
+      showExamples={true}
     />
   </tbody>
 </styled.table>


### PR DESCRIPTION
I'd like Redoc to support examples inside ObjectSchema fields. 

![image](https://user-images.githubusercontent.com/22104189/66510883-88f37d80-ea9b-11e9-8adb-ed5f6789dd95.png)
