### PR TITLE
Resolve formatting bugs.

### DIFF
--- a/demo/openapi.yaml
+++ b/demo/openapi.yaml
@@ -86,6 +86,14 @@ x-tagGroups:
 paths:
   /pet:
     parameters:
+      - name: Accept-Language
+        in: header
+        description: "The language you prefer for messages. Supported values are en-AU, en-CA, en-GB, en-US"
+        example: en-US
+        required: false
+        schema:
+          type: string
+          default: en-AU
       - name: cookieParam
         in: cookie
         description: Some cookie
@@ -678,6 +686,7 @@ components:
               type: string
               description: The measured skill for hunting
               default: lazy
+              example: adventurous
               enum:
                 - clueless
                 - lazy
@@ -890,7 +899,6 @@ components:
           type: string
           pattern: '/^\+(?:[0-9]-?){6,14}[0-9]$/'
           example: +1-202-555-0192
-          nullable: true
         userStatus:
           description: User status
           type: integer

--- a/src/components/Fields/FieldDetails.tsx
+++ b/src/components/Fields/FieldDetails.tsx
@@ -31,6 +31,8 @@ export class FieldDetails extends React.PureComponent<FieldProps> {
 
     const { schema, description, example, deprecated } = field;
 
+    const rawDefault = !!enumSkipQuotes || field.in === 'header'; // having quotes around header field default values is confusing and inappropriate
+
     let exampleField: JSX.Element | null = null;
 
     if (showExamples && example !== undefined) {
@@ -59,7 +61,7 @@ export class FieldDetails extends React.PureComponent<FieldProps> {
           {schema.title && <TypeTitle> ({schema.title}) </TypeTitle>}
           <ConstraintsView constraints={schema.constraints} />
           {schema.nullable && <NullableLabel> {l('nullable')} </NullableLabel>}
-          {schema.pattern && <PatternLabel>{schema.pattern}</PatternLabel>}
+          {schema.pattern && <PatternLabel> {schema.pattern} </PatternLabel>}
           {schema.isCircular && <RecursiveLabel> {l('recursive')} </RecursiveLabel>}
         </div>
         {deprecated && (
@@ -67,7 +69,7 @@ export class FieldDetails extends React.PureComponent<FieldProps> {
             <Badge type="warning"> {l('deprecated')} </Badge>
           </div>
         )}
-        <FieldDetail raw={enumSkipQuotes} label={l('default') + ':'} value={schema.default} />
+        <FieldDetail raw={rawDefault} label={l('default') + ':'} value={schema.default} />
         {!renderDiscriminatorSwitch && <EnumValues type={schema.type} values={schema.enum} />}{' '}
         {exampleField}
         {<Extensions extensions={{ ...field.extensions, ...schema.extensions }} />}


### PR DESCRIPTION
**No quotes for default values in header fields.**
In a header field/parameter line Accept-Language, instead of 
`Default: "en-US"`
(which is ugly and just wrong), you now get:
`Default: en-US`

**Spaces around the pattern values.**
Instead of:
`string/^\d+$/`
you now get:
`string /^\d+$/`

Small README improvement.