### PR TITLE
feat(cli): Fallback on the spec's title before falling back on "ReDoc documentation"

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -99,7 +99,6 @@ YargsParser.command(
       yargs.options('title', {
         describe: 'Page Title',
         type: 'string',
-        default: 'ReDoc documentation',
       });
 
       yargs.options('disableGoogleFont', {
@@ -291,7 +290,7 @@ async function getPageHTML(
         ? '<script src="https://unpkg.com/redoc@next/bundles/redoc.standalone.js"></script>'
         : `<script>${redocStandaloneSrc}</script>`) + css
       : '<script src="redoc.standalone.js"></script>',
-    title,
+    title: title || spec.info.title || 'ReDoc documentation',
     disableGoogleFont,
     templateOptions,
   });


### PR DESCRIPTION
Instead of using "ReDoc documentation" straight away as the title of the HTML page rendered by `redoc-cli`, it tries to use the specification's title in its info object.

I haven't seen any place to write tests for the cli tool, so I didn't write any.  
However, here are the three possible test cases and expected results: 

#### Title provided using `--title`
Command: `redoc-cli bundle spec.yaml --title "Your Awesome Title"`
OpenAPI spec title: "Another title" | null
HTML page title (result): "Your Awesome Title"

#### Title provided in the specification file
Command: `redoc-cli bundle spec.yaml`
OpenAPI spec title: "Your Awesome Title"
HTML page title (result): "Your Awesome Title"

#### No title provided
Command: `redoc-cli bundle spec.yaml`
OpenAPI spec title: null
HTML page title (result): "ReDoc documentation"

I've still made sure that everything was prettified and linted which made me discover the issue #1072.

Fixes #1068