### PR TITLE
Fixed example slack api url

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -11,7 +11,7 @@ const demos = [
     value: 'https://api.apis.guru/v2/specs/googleapis.com/calendar/v3/swagger.yaml',
     label: 'Google Calendar',
   },
-  { value: 'https://api.apis.guru/v2/specs/slack.com/1.0.6/swagger.yaml', label: 'Slack' },
+  { value: 'https://api.apis.guru/v2/specs/slack.com/1.2.0/swagger.yaml', label: 'Slack' },
   { value: 'https://api.apis.guru/v2/specs/zoom.us/2.0.0/swagger.yaml', label: 'Zoom.us' },
   {
     value: 'https://api.apis.guru/v2/specs/graphhopper.com/1.0/swagger.yaml',


### PR DESCRIPTION
Since this seems like something that happens once in a while, is there a reason to not use a permalink, like linking to the yaml file in the apis.guru repo?
https://raw.githubusercontent.com/APIs-guru/openapi-directory/c8d61eeb3c52504cbe006838093897df20682342/APIs/slack.com/1.2.0/swagger.yaml