### PR TITLE
[FEATURE] Add callback support

### DIFF
--- a/src/components/CallbackSamples/CallbackSamples.tsx
+++ b/src/components/CallbackSamples/CallbackSamples.tsx
@@ -1,0 +1,87 @@
+import { observer } from 'mobx-react';
+import * as React from 'react';
+import { isPayloadSample, RedocNormalizedOptions } from '../../services';
+import { PayloadSamples } from '../PayloadSamples/PayloadSamples';
+import { SourceCodeWithCopy } from '../SourceCode/SourceCode';
+
+import { RightPanelHeader, Tab, TabList, TabPanel, Tabs } from '../../common-elements';
+import { OptionsContext } from '../OptionsProvider';
+import { CallbackModel } from '../../services/models';
+import { Endpoint } from '../Endpoint/Endpoint';
+
+export interface CallbackSamplesProps {
+  callbacks: CallbackModel[];
+}
+
+@observer
+export class CallbackSamples extends React.Component<CallbackSamplesProps> {
+  static contextType = OptionsContext;
+  context: RedocNormalizedOptions;
+
+  render() {
+    const { callbacks } = this.props;
+
+    // Sums number of code samples per operation per callback
+    const numSamples = callbacks.reduce(
+      (callbackSum, callback) =>
+        callbackSum +
+        callback.operations.reduce(
+          (sampleSum, operation) => sampleSum + operation.codeSamples.length,
+          0,
+        ),
+      0,
+    );
+
+    const hasSamples = numSamples > 0;
+    const hideTabList = numSamples === 1 ? this.context.hideSingleRequestSampleTab : false;
+
+    const renderTabs = () => {
+      return callbacks.map(callback => {
+        return callback.operations.map(operation => {
+          return operation.codeSamples.map(sample => {
+            return (
+              <Tab key={operation.id + '_' + operation.name}>
+                {operation.name} {sample.label !== undefined ? sample.label : sample.lang}
+              </Tab>
+            );
+          });
+        });
+      });
+    };
+
+    const renderTabPanels = () => {
+      return callbacks.map(callback => {
+        return callback.operations.map(operation => {
+          return operation.codeSamples.map(sample => {
+            return (
+              <TabPanel key={sample.lang + '_' + (sample.label || '')}>
+                {isPayloadSample(sample) ? (
+                  <div>
+                    <Endpoint operation={operation} inverted={false} />
+                    <PayloadSamples content={sample.requestBodyContent} />
+                  </div>
+                ) : (
+                  <SourceCodeWithCopy lang={sample.lang} source={sample.source} />
+                )}
+              </TabPanel>
+            );
+          });
+        });
+      });
+    };
+
+    return (
+      (hasSamples && (
+        <div>
+          <RightPanelHeader> Callback samples </RightPanelHeader>
+
+          <Tabs defaultIndex={0}>
+            <TabList hidden={hideTabList}>{renderTabs()}</TabList>
+            {renderTabPanels()}
+          </Tabs>
+        </div>
+      )) ||
+      null
+    );
+  }
+}

--- a/src/components/CallbackSamples/CallbackSamples.tsx
+++ b/src/components/CallbackSamples/CallbackSamples.tsx
@@ -1,13 +1,13 @@
 import { observer } from 'mobx-react';
 import * as React from 'react';
-import { isPayloadSample, RedocNormalizedOptions } from '../../services';
-import { PayloadSamples } from '../PayloadSamples/PayloadSamples';
-import { SourceCodeWithCopy } from '../SourceCode/SourceCode';
 
 import { RightPanelHeader, Tab, TabList, TabPanel, Tabs } from '../../common-elements';
-import { OptionsContext } from '../OptionsProvider';
+import { isPayloadSample, RedocNormalizedOptions } from '../../services';
 import { CallbackModel } from '../../services/models';
 import { Endpoint } from '../Endpoint/Endpoint';
+import { OptionsContext } from '../OptionsProvider';
+import { PayloadSamples } from '../PayloadSamples/PayloadSamples';
+import { SourceCodeWithCopy } from '../SourceCode/SourceCode';
 
 export interface CallbackSamplesProps {
   callbacks: CallbackModel[];

--- a/src/components/Callbacks/Callback.tsx
+++ b/src/components/Callbacks/Callback.tsx
@@ -1,0 +1,26 @@
+import { observer } from 'mobx-react';
+import * as React from 'react';
+import { CallbackModel } from '../../services/models';
+import { CallbackDetailsWrap, StyledCallbackTitle } from '../Callbacks/styled.elements';
+
+@observer
+export class CallbackView extends React.Component<{ callback: CallbackModel }> {
+  toggle = () => {
+    this.props.callback.toggle();
+  };
+
+  render() {
+    const { name, expanded } = this.props.callback;
+
+    return (
+      <div>
+        <StyledCallbackTitle onClick={this.toggle} name={name} opened={expanded} />
+        {expanded && (
+          <CallbackDetailsWrap>
+            <span>{name}</span>
+          </CallbackDetailsWrap>
+        )}
+      </div>
+    );
+  }
+}

--- a/src/components/Callbacks/Callback.tsx
+++ b/src/components/Callbacks/Callback.tsx
@@ -1,23 +1,29 @@
 import { observer } from 'mobx-react';
 import * as React from 'react';
-import { CallbackModel } from '../../services/models';
+import { OperationModel } from '../../services/models';
+import { CallbackDetails } from './CallbackDetails';
 import { CallbackDetailsWrap, StyledCallbackTitle } from '../Callbacks/styled.elements';
 
 @observer
-export class CallbackView extends React.Component<{ callback: CallbackModel }> {
+export class CallbackView extends React.Component<{ callbackOperation: OperationModel }> {
   toggle = () => {
-    this.props.callback.toggle();
+    this.props.callbackOperation.toggle();
   };
 
   render() {
-    const { name, expanded } = this.props.callback;
+    const { name, description, expanded } = this.props.callbackOperation;
 
     return (
       <div>
-        <StyledCallbackTitle onClick={this.toggle} name={name} opened={expanded} />
+        <StyledCallbackTitle
+          onClick={this.toggle}
+          name={name}
+          description={description}
+          opened={expanded}
+        />
         {expanded && (
           <CallbackDetailsWrap>
-            <span>{name}</span>
+            <CallbackDetails callbackOperation={this.props.callbackOperation} />
           </CallbackDetailsWrap>
         )}
       </div>

--- a/src/components/Callbacks/Callback.tsx
+++ b/src/components/Callbacks/Callback.tsx
@@ -1,8 +1,9 @@
 import { observer } from 'mobx-react';
 import * as React from 'react';
+
 import { OperationModel } from '../../services/models';
-import { CallbackDetails } from './CallbackDetails';
 import { CallbackDetailsWrap, StyledCallbackTitle } from '../Callbacks/styled.elements';
+import { CallbackDetails } from './CallbackDetails';
 
 @observer
 export class CallbackView extends React.Component<{ callbackOperation: OperationModel }> {

--- a/src/components/Callbacks/CallbackDetails.tsx
+++ b/src/components/Callbacks/CallbackDetails.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { OperationModel } from '../../services/models';
+import { OperationItem } from '../ContentItems/ContentItems';
+
+export class CallbackDetails extends React.PureComponent<{ callbackOperation: OperationModel }> {
+  render() {
+    return <OperationItem item={this.props.callbackOperation} />;
+  }
+}

--- a/src/components/Callbacks/CallbackDetails.tsx
+++ b/src/components/Callbacks/CallbackDetails.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { OperationModel } from '../../services/models';
 import { OperationItem } from '../ContentItems/ContentItems';
 

--- a/src/components/Callbacks/CallbackTitle.tsx
+++ b/src/components/Callbacks/CallbackTitle.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { ShelfIcon } from '../../common-elements';
+
+export interface CallbackTitleProps {
+  name: string;
+  opened?: boolean;
+  className?: string;
+  onClick?: () => void;
+}
+
+export class CallbackTitle extends React.PureComponent<CallbackTitleProps> {
+  render() {
+    const { name, opened, className, onClick } = this.props;
+    return (
+      <div className={className} onClick={onClick || undefined}>
+        <ShelfIcon size={'1.5em'} direction={opened ? 'up' : 'down'} float={'left'} />
+        <strong>{name} </strong>
+      </div>
+    );
+  }
+}

--- a/src/components/Callbacks/CallbackTitle.tsx
+++ b/src/components/Callbacks/CallbackTitle.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 
 import { ShelfIcon } from '../../common-elements';
+import { Markdown } from '../Markdown/Markdown';
 
 export interface CallbackTitleProps {
   name: string;
+  description?: string;
   opened?: boolean;
   className?: string;
   onClick?: () => void;
@@ -11,11 +13,12 @@ export interface CallbackTitleProps {
 
 export class CallbackTitle extends React.PureComponent<CallbackTitleProps> {
   render() {
-    const { name, opened, className, onClick } = this.props;
+    const { name, description, opened, className, onClick } = this.props;
     return (
       <div className={className} onClick={onClick || undefined}>
-        <ShelfIcon size={'1.5em'} direction={opened ? 'up' : 'down'} float={'left'} />
+        <ShelfIcon size={'1.5em'} direction={opened ? 'down' : 'right'} float={'left'} />
         <strong>{name} </strong>
+        {description && <Markdown compact={true} inline={true} source={description} />}
       </div>
     );
   }

--- a/src/components/Callbacks/CallbacksList.tsx
+++ b/src/components/Callbacks/CallbacksList.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { CallbackModel } from '../../services/models';
+import styled from '../../styled-components';
+import { CallbackView } from './Callback';
+
+const CallbacksHeader = styled.h3`
+  font-size: 18px;
+  padding: 0.2em 0;
+  margin: 3em 0 1.1em;
+  color: #253137;
+  font-weight: normal;
+`;
+
+export interface CallbacksListProps {
+  callbacks: CallbackModel[];
+}
+
+export class CallbacksList extends React.PureComponent<CallbacksListProps> {
+  render() {
+    const { callbacks } = this.props;
+
+    if (!callbacks || callbacks.length === 0) {
+      return null;
+    }
+
+    return (
+      <div>
+        <CallbacksHeader> Callbacks </CallbacksHeader>
+        {callbacks.map(callback => {
+          return <CallbackView key={callback.name} callback={callback} />;
+        })}
+      </div>
+    );
+  }
+}

--- a/src/components/Callbacks/CallbacksList.tsx
+++ b/src/components/Callbacks/CallbacksList.tsx
@@ -27,7 +27,9 @@ export class CallbacksList extends React.PureComponent<CallbacksListProps> {
       <div>
         <CallbacksHeader> Callbacks </CallbacksHeader>
         {callbacks.map(callback => {
-          return <CallbackView key={callback.name} callback={callback} />;
+          return callback.operations.map(operation => {
+            return <CallbackView key={callback.name} callbackOperation={operation} />;
+          });
         })}
       </div>
     );

--- a/src/components/Callbacks/CallbacksList.tsx
+++ b/src/components/Callbacks/CallbacksList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { CallbackModel } from '../../services/models';
 import styled from '../../styled-components';
 import { CallbackView } from './Callback';

--- a/src/components/Callbacks/index.ts
+++ b/src/components/Callbacks/index.ts
@@ -1,0 +1,3 @@
+export * from './Callback';
+export * from './CallbackTitle';
+export * from './CallbacksList';

--- a/src/components/Callbacks/styled.elements.ts
+++ b/src/components/Callbacks/styled.elements.ts
@@ -1,0 +1,15 @@
+import styled from '../../styled-components';
+import { CallbackTitle } from './CallbackTitle';
+
+export const StyledCallbackTitle = styled(CallbackTitle)`
+  padding: 10px;
+  border-radius: 2px;
+  margin-bottom: 4px;
+  line-height: 1.5em;
+  background-color: #f2f2f2;
+  cursor: pointer;
+`;
+
+export const CallbackDetailsWrap = styled.div`
+  padding: 10px;
+`;

--- a/src/components/ContentItems/ContentItems.tsx
+++ b/src/components/ContentItems/ContentItems.tsx
@@ -32,7 +32,7 @@ export class ContentItems extends React.Component<{
         return (
           <React.Fragment key={item.id}>
             <ContentItem item={item} />
-            <CallbacksHeader>Callbacks:</CallbacksHeader>
+            <CallbacksHeader>Callbacks</CallbacksHeader>
             {item.callbacks.map((callbackIndex, idx) => {
               return <ContentItems key={idx} items={callbackIndex.operations} />;
             })}

--- a/src/components/ContentItems/ContentItems.tsx
+++ b/src/components/ContentItems/ContentItems.tsx
@@ -8,15 +8,6 @@ import { Operation } from '..';
 import { H1, H2, MiddlePanel, Row, Section, ShareLink } from '../../common-elements';
 import { ContentItemModel } from '../../services';
 import { GroupModel, OperationModel } from '../../services/models';
-import styled from '../../styled-components';
-
-const CallbacksHeader = styled.h3`
-  font-size: 18px;
-  padding: 0 40px;
-  margin: 3em 0 1.1em;
-  color: #253137;
-  font-weight: normal;
-`;
 
 @observer
 export class ContentItems extends React.Component<{
@@ -28,18 +19,6 @@ export class ContentItems extends React.Component<{
       return null;
     }
     return items.map(item => {
-      if (item.type === 'operation' && item.callbacks.length > 0) {
-        return (
-          <React.Fragment key={item.id}>
-            <ContentItem item={item} />
-            <CallbacksHeader>Callbacks</CallbacksHeader>
-            {item.callbacks.map((callbackIndex, idx) => {
-              return <ContentItems key={idx} items={callbackIndex.operations} />;
-            })}
-          </React.Fragment>
-        );
-      }
-
       return <ContentItem key={item.id} item={item} />;
     });
   }

--- a/src/components/ContentItems/ContentItems.tsx
+++ b/src/components/ContentItems/ContentItems.tsx
@@ -4,10 +4,19 @@ import * as React from 'react';
 import { ExternalDocumentation } from '../ExternalDocumentation/ExternalDocumentation';
 import { AdvancedMarkdown } from '../Markdown/AdvancedMarkdown';
 
+import { Operation } from '..';
 import { H1, H2, MiddlePanel, Row, Section, ShareLink } from '../../common-elements';
-import { ContentItemModel } from '../../services/MenuBuilder';
+import { ContentItemModel } from '../../services';
 import { GroupModel, OperationModel } from '../../services/models';
-import { Operation } from '../Operation/Operation';
+import styled from '../../styled-components';
+
+const CallbacksHeader = styled.h3`
+  font-size: 18px;
+  padding: 0 40px;
+  margin: 3em 0 1.1em;
+  color: #253137;
+  font-weight: normal;
+`;
 
 @observer
 export class ContentItems extends React.Component<{
@@ -18,7 +27,21 @@ export class ContentItems extends React.Component<{
     if (items.length === 0) {
       return null;
     }
-    return items.map(item => <ContentItem item={item} key={item.id} />);
+    return items.map(item => {
+      if (item.type === 'operation' && item.callbacks.length > 0) {
+        return (
+          <React.Fragment key={item.id}>
+            <ContentItem item={item} />
+            <CallbacksHeader>Callbacks:</CallbacksHeader>
+            {item.callbacks.map((callbackIndex, idx) => {
+              return <ContentItems key={idx} items={callbackIndex.operations} />;
+            })}
+          </React.Fragment>
+        );
+      }
+
+      return <ContentItem key={item.id} item={item} />;
+    });
   }
 }
 

--- a/src/components/Operation/Operation.tsx
+++ b/src/components/Operation/Operation.tsx
@@ -1,26 +1,22 @@
-import * as React from 'react';
-import { SecurityRequirements } from '../SecurityRequirement/SecurityRequirement';
-
 import { observer } from 'mobx-react';
+import * as React from 'react';
 
 import { Badge, DarkRightPanel, H2, MiddlePanel, Row } from '../../common-elements';
-
-import { OptionsContext } from '../OptionsProvider';
-
 import { ShareLink } from '../../common-elements/linkify';
+import { OperationModel as OperationType } from '../../services/models';
+import styled from '../../styled-components';
+import { CallbacksList } from '../Callbacks';
+import { CallbackSamples } from '../CallbackSamples/CallbackSamples';
 import { Endpoint } from '../Endpoint/Endpoint';
 import { ExternalDocumentation } from '../ExternalDocumentation/ExternalDocumentation';
+import { Extensions } from '../Fields/Extensions';
 import { Markdown } from '../Markdown/Markdown';
+import { OptionsContext } from '../OptionsProvider';
 import { Parameters } from '../Parameters/Parameters';
 import { RequestSamples } from '../RequestSamples/RequestSamples';
 import { ResponsesList } from '../Responses/ResponsesList';
 import { ResponseSamples } from '../ResponseSamples/ResponseSamples';
-import { CallbacksList } from '../Callbacks';
-import { CallbackSamples } from '../CallbackSamples/CallbackSamples';
-
-import { OperationModel as OperationType } from '../../services/models';
-import styled from '../../styled-components';
-import { Extensions } from '../Fields/Extensions';
+import { SecurityRequirements } from '../SecurityRequirement/SecurityRequirement';
 
 const CallbackMiddlePanel = styled(MiddlePanel)`
   width: 100%;

--- a/src/components/Operation/Operation.tsx
+++ b/src/components/Operation/Operation.tsx
@@ -15,10 +15,17 @@ import { Parameters } from '../Parameters/Parameters';
 import { RequestSamples } from '../RequestSamples/RequestSamples';
 import { ResponsesList } from '../Responses/ResponsesList';
 import { ResponseSamples } from '../ResponseSamples/ResponseSamples';
+import { CallbacksList } from '../Callbacks';
+import { CallbackSamples } from '../CallbackSamples/CallbackSamples';
 
 import { OperationModel as OperationType } from '../../services/models';
 import styled from '../../styled-components';
 import { Extensions } from '../Fields/Extensions';
+
+const CallbackMiddlePanel = styled(MiddlePanel)`
+  width: 100%;
+  padding: 0;
+`;
 
 const OperationRow = styled(Row)`
   backface-visibility: hidden;
@@ -42,18 +49,23 @@ export class Operation extends React.Component<OperationProps> {
 
     const { name: summary, description, deprecated, externalDocs } = operation;
     const hasDescription = !!(description || externalDocs);
+    const AdaptiveMiddlePanel = operation.isCallback ? CallbackMiddlePanel : MiddlePanel;
 
     return (
       <OptionsContext.Consumer>
         {options => (
           <OperationRow>
-            <MiddlePanel>
-              <H2>
-                <ShareLink to={operation.id} />
-                {summary} {deprecated && <Badge type="warning"> Deprecated </Badge>}
-              </H2>
-              {options.pathInMiddlePanel && <Endpoint operation={operation} inverted={true} />}
-              {hasDescription && (
+            <AdaptiveMiddlePanel>
+              {!operation.isCallback && (
+                <H2>
+                  <ShareLink to={operation.id} />
+                  {summary} {deprecated && <Badge type="warning"> Deprecated </Badge>}
+                </H2>
+              )}
+              {!operation.isCallback && options.pathInMiddlePanel && (
+                <Endpoint operation={operation} inverted={true} />
+              )}
+              {!operation.isCallback && hasDescription && (
                 <Description>
                   {description !== undefined && <Markdown source={description} />}
                   {externalDocs && <ExternalDocumentation externalDocs={externalDocs} />}
@@ -63,12 +75,18 @@ export class Operation extends React.Component<OperationProps> {
               <SecurityRequirements securities={operation.security} />
               <Parameters parameters={operation.parameters} body={operation.requestBody} />
               <ResponsesList responses={operation.responses} />
-            </MiddlePanel>
-            <DarkRightPanel>
-              {!options.pathInMiddlePanel && <Endpoint operation={operation} />}
-              <RequestSamples operation={operation} />
-              <ResponseSamples operation={operation} />
-            </DarkRightPanel>
+              <CallbacksList callbacks={operation.callbacks} />
+            </AdaptiveMiddlePanel>
+            {!operation.isCallback && (
+              <DarkRightPanel>
+                {!options.pathInMiddlePanel && <Endpoint operation={operation} />}
+                <RequestSamples operation={operation} />
+                <ResponseSamples operation={operation} />
+                {operation.callbacks.length > 0 && (
+                  <CallbackSamples callbacks={operation.callbacks} />
+                )}
+              </DarkRightPanel>
+            )}
           </OperationRow>
         )}
       </OptionsContext.Consumer>

--- a/src/components/__tests__/Callbacks.test.tsx
+++ b/src/components/__tests__/Callbacks.test.tsx
@@ -4,9 +4,10 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { OpenAPIParser } from '../../services';
-import { CallbackModel } from '../../services/models/Callback';
-import { CallbackView, CallbacksList, CallbackTitle } from '../Callbacks';
 import { RedocNormalizedOptions } from '../../services/RedocNormalizedOptions';
+
+import { CallbackModel } from '../../services/models/Callback';
+import { CallbacksList, CallbackTitle, CallbackView } from '../Callbacks';
 import * as simpleCallbackFixture from './fixtures/simple-callback.json';
 
 const options = new RedocNormalizedOptions({});

--- a/src/components/__tests__/Callbacks.test.tsx
+++ b/src/components/__tests__/Callbacks.test.tsx
@@ -1,0 +1,56 @@
+/* tslint:disable:no-implicit-dependencies */
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { OpenAPIParser } from '../../services';
+import { CallbackModel } from '../../services/models/Callback';
+import { CallbackView, CallbacksList, CallbackTitle } from '../Callbacks';
+import { RedocNormalizedOptions } from '../../services/RedocNormalizedOptions';
+import * as simpleCallbackFixture from './fixtures/simple-callback.json';
+
+const options = new RedocNormalizedOptions({});
+describe('Components', () => {
+  describe('Callbacks', () => {
+    it('should correctly render CallbackView', () => {
+      const parser = new OpenAPIParser(simpleCallbackFixture, undefined, options);
+      const callback = new CallbackModel(
+        parser,
+        'Test.Callback',
+        { $ref: '#/components/callbacks/Test' },
+        options,
+      );
+      const callbackViewElement = shallow(
+        <CallbackView key={callback.name} callback={callback} />,
+      ).getElement();
+      expect(callbackViewElement.props).toBeDefined();
+      expect(callbackViewElement.props.children).toBeDefined();
+      expect(callbackViewElement.props.children.length).toBeGreaterThan(0);
+    });
+
+    it('should correctly render CallbackTitle', () => {
+      const callbackTitleViewElement = shallow(
+        <CallbackTitle name={'Test'} className={'.test'} onClick={undefined} />,
+      ).getElement();
+      expect(callbackTitleViewElement.props).toBeDefined();
+      expect(callbackTitleViewElement.props.className).toEqual('.test');
+      expect(callbackTitleViewElement.props.onClick).toBeUndefined();
+    });
+
+    it('should correctly render CallbacksList', () => {
+      const parser = new OpenAPIParser(simpleCallbackFixture, undefined, options);
+      const callback = new CallbackModel(
+        parser,
+        'Test.Callback',
+        { $ref: '#/components/callbacks/Test' },
+        options,
+      );
+      const callbacksListViewElement = shallow(
+        <CallbacksList callbacks={[callback]} />,
+      ).getElement();
+      expect(callbacksListViewElement.props).toBeDefined();
+      expect(callbacksListViewElement.props.children).toBeDefined();
+      expect(callbacksListViewElement.props.children.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/components/__tests__/Callbacks.test.tsx
+++ b/src/components/__tests__/Callbacks.test.tsx
@@ -22,7 +22,7 @@ describe('Components', () => {
         options,
       );
       const callbackViewElement = shallow(
-        <CallbackView key={callback.name} callback={callback} />,
+        <CallbackView key={callback.name} callbackOperation={callback.operations[0]} />,
       ).getElement();
       expect(callbackViewElement.props).toBeDefined();
       expect(callbackViewElement.props.children).toBeDefined();

--- a/src/components/__tests__/Callbacks.test.tsx
+++ b/src/components/__tests__/Callbacks.test.tsx
@@ -4,9 +4,8 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { OpenAPIParser } from '../../services';
-import { RedocNormalizedOptions } from '../../services/RedocNormalizedOptions';
-
 import { CallbackModel } from '../../services/models/Callback';
+import { RedocNormalizedOptions } from '../../services/RedocNormalizedOptions';
 import { CallbacksList, CallbackTitle, CallbackView } from '../Callbacks';
 import * as simpleCallbackFixture from './fixtures/simple-callback.json';
 
@@ -21,6 +20,7 @@ describe('Components', () => {
         { $ref: '#/components/callbacks/Test' },
         options,
       );
+      // There should be 1 operation defined in simple-callback.json, just get it manually for readability.
       const callbackViewElement = shallow(
         <CallbackView key={callback.name} callbackOperation={callback.operations[0]} />,
       ).getElement();

--- a/src/components/__tests__/fixtures/simple-callback.json
+++ b/src/components/__tests__/fixtures/simple-callback.json
@@ -1,0 +1,64 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+      "version": "1.0",
+      "title": "Foo"
+    },
+    "components": {
+      "callbacks": {
+        "Test": {
+            "post": {
+              "operationId": "testCallback",
+              "description": "Test callback.",
+              "requestBody": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "title": "TestTitle",
+                      "type": "object",
+                      "description": "Test description",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "The type of response.",
+                          "enum": [
+                            "TestResponse.Complete"
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "FAILURE",
+                            "SUCCESS"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "status"
+                      ]
+                    }
+                  }
+                }
+              },
+              "parameters": [
+                {
+                  "name": "X-Test-Header",
+                  "in": "header",
+                  "required": true,
+                  "example": "1",
+                  "description": "This is a test header parameter",
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "responses": {
+                "204": {
+                  "description": "Test response."
+                }
+              }
+            }
+          }
+      }
+    }
+  }

--- a/src/components/__tests__/fixtures/simple-callback.json
+++ b/src/components/__tests__/fixtures/simple-callback.json
@@ -1,64 +1,66 @@
 {
-    "openapi": "3.0.0",
-    "info": {
-      "version": "1.0",
-      "title": "Foo"
-    },
-    "components": {
-      "callbacks": {
-        "Test": {
-            "post": {
-              "operationId": "testCallback",
-              "description": "Test callback.",
-              "requestBody": {
-                "content": {
-                  "application/json": {
-                    "schema": {
-                      "title": "TestTitle",
-                      "type": "object",
-                      "description": "Test description",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "description": "The type of response.",
-                          "enum": [
-                            "TestResponse.Complete"
-                          ]
-                        },
-                        "status": {
-                          "type": "string",
-                          "enum": [
-                            "FAILURE",
-                            "SUCCESS"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "status"
-                      ]
-                    }
-                  }
-                }
-              },
-              "parameters": [
-                {
-                  "name": "X-Test-Header",
-                  "in": "header",
-                  "required": true,
-                  "example": "1",
-                  "description": "This is a test header parameter",
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "Foo"
+  },
+  "components": {
+    "callbacks": {
+      "Test": {
+        "/test": {
+          "post": {
+            "operationId": "testCallback",
+            "description": "Test callback.",
+            "requestBody": {
+              "content": {
+                "application/json": {
                   "schema": {
-                    "type": "string"
+                    "title": "TestTitle",
+                    "type": "object",
+                    "description": "Test description",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "The type of response.",
+                        "enum": [
+                          "TestResponse.Complete"
+                        ]
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": [
+                          "FAILURE",
+                          "SUCCESS"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "status"
+                    ]
                   }
                 }
-              ],
-              "responses": {
-                "204": {
-                  "description": "Test response."
+              }
+            },
+            "parameters": [
+              {
+                "name": "X-Test-Header",
+                "in": "header",
+                "required": true,
+                "example": "1",
+                "description": "This is a test header parameter",
+                "schema": {
+                  "type": "string"
                 }
+              }
+            ],
+            "responses": {
+              "204": {
+                "description": "Test response."
               }
             }
           }
+        }
       }
     }
   }
+}

--- a/src/services/__tests__/fixtures/callback.json
+++ b/src/services/__tests__/fixtures/callback.json
@@ -1,0 +1,64 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+      "version": "1.0",
+      "title": "Foo"
+    },
+    "components": {
+      "callbacks": {
+        "Test": {
+            "post": {
+              "operationId": "testCallback",
+              "description": "Test callback.",
+              "requestBody": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "title": "TestTitle",
+                      "type": "object",
+                      "description": "Test description",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "The type of response.",
+                          "enum": [
+                            "TestResponse.Complete"
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "FAILURE",
+                            "SUCCESS"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "status"
+                      ]
+                    }
+                  }
+                }
+              },
+              "parameters": [
+                {
+                  "name": "X-Test-Header",
+                  "in": "header",
+                  "required": true,
+                  "example": "1",
+                  "description": "This is a test header parameter",
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "responses": {
+                "204": {
+                  "description": "Test response."
+                }
+              }
+            }
+          }
+      }
+    }
+  }

--- a/src/services/__tests__/models/Callback.test.ts
+++ b/src/services/__tests__/models/Callback.test.ts
@@ -1,0 +1,26 @@
+import { CallbackModel } from '../../models/Callback';
+import { OpenAPIParser } from '../../OpenAPIParser';
+import { RedocNormalizedOptions } from '../../RedocNormalizedOptions';
+
+const opts = new RedocNormalizedOptions({});
+
+describe('Models', () => {
+  describe('CallbackModel', () => {
+    let parser;
+    const spec = require('../fixtures/callback.json');
+    parser = new OpenAPIParser(spec, undefined, opts);
+
+    test('basic callback details', () => {
+      const callback = new CallbackModel(
+        parser,
+        'Test.Callback',
+        { $ref: '#/components/callbacks/Test' },
+        opts,
+      );
+      expect(callback.name).toEqual('Test.Callback');
+      expect(callback.operations.length).toEqual(0);
+      expect(callback.paths).toBeDefined();
+      expect(callback.expanded).toBeUndefined();
+    });
+  });
+});

--- a/src/services/models/Callback.ts
+++ b/src/services/models/Callback.ts
@@ -1,0 +1,55 @@
+import { action, observable } from 'mobx';
+import { OpenAPICallback, Referenced } from '../../types';
+import { isOperationName } from '../../utils';
+import { OpenAPIParser } from '../OpenAPIParser';
+import { OperationModel } from './Operation';
+
+export class CallbackModel {
+  @observable
+  expanded: boolean;
+  name: string;
+  paths: Referenced<OpenAPICallback>;
+  operations: OperationModel[] = [];
+
+  constructor(
+    parser: OpenAPIParser,
+    name: string,
+    infoOrRef: Referenced<OpenAPICallback>,
+    options,
+  ) {
+    this.name = name;
+    this.paths = parser.deref(infoOrRef);
+    parser.exitRef(infoOrRef);
+
+    for (const pathName of Object.keys(this.paths)) {
+      const path = this.paths[pathName];
+      const operations = Object.keys(path).filter(isOperationName);
+      for (const operationName of operations) {
+        const operationInfo = path[operationName];
+
+        const operation = new OperationModel(
+          parser,
+          {
+            ...operationInfo,
+            pathName,
+            httpVerb: operationName,
+            pathParameters: path.parameters || [],
+          },
+          undefined,
+          options,
+          true,
+          this.name,
+        );
+
+        this.operations.push(operation);
+      }
+    }
+
+    console.log(this.operations);
+  }
+
+  @action
+  toggle() {
+    this.expanded = !this.expanded;
+  }
+}

--- a/src/services/models/Callback.ts
+++ b/src/services/models/Callback.ts
@@ -44,8 +44,6 @@ export class CallbackModel {
         this.operations.push(operation);
       }
     }
-
-    console.log(this.operations);
   }
 
   @action

--- a/src/services/models/Callback.ts
+++ b/src/services/models/Callback.ts
@@ -1,4 +1,5 @@
 import { action, observable } from 'mobx';
+
 import { OpenAPICallback, Referenced } from '../../types';
 import { isOperationName } from '../../utils';
 import { OpenAPIParser } from '../OpenAPIParser';

--- a/src/services/models/Operation.ts
+++ b/src/services/models/Operation.ts
@@ -122,6 +122,7 @@ export class OperationModel implements IMenuItem {
       this.security = (operationSpec.security || parser.spec.security || []).map(
         security => new SecurityRequirementModel(security, parser),
       );
+    }
 
     const requestBodyContent = this.requestBody && this.requestBody.content;
     if (requestBodyContent && requestBodyContent.hasSample) {

--- a/src/services/models/Operation.ts
+++ b/src/services/models/Operation.ts
@@ -107,7 +107,6 @@ export class OperationModel implements IMenuItem {
     this.operationId = operationSpec.operationId;
     this.path = operationSpec.pathName;
     this.isCallback = isCallback;
-    this.codeSamples = operationSpec['x-code-samples'] || [];
 
     if (this.isCallback) {
       // NOTE: Use callback's event name as the view label, not the operationID.
@@ -122,22 +121,6 @@ export class OperationModel implements IMenuItem {
       this.security = (operationSpec.security || parser.spec.security || []).map(
         security => new SecurityRequirementModel(security, parser),
       );
-    }
-
-    const requestBodyContent = this.requestBody && this.requestBody.content;
-    if (requestBodyContent && requestBodyContent.hasSample) {
-      const insertInx = Math.min(this.codeSamples.length, options.payloadSampleIdx);
-
-      this.codeSamples = [
-        ...this.codeSamples.slice(0, insertInx),
-        {
-          lang: 'payload',
-          label: 'Payload',
-          source: '',
-          requestBodyContent,
-        },
-        ...this.codeSamples.slice(insertInx),
-      ];
     }
 
     const pathInfo = parser.byRef<OpenAPIPath>(

--- a/src/services/models/Operation.ts
+++ b/src/services/models/Operation.ts
@@ -172,6 +172,14 @@ export class OperationModel implements IMenuItem {
     this.active = false;
   }
 
+  /**
+   * Toggle expansion in middle panel (for callbacks, which are operations)
+   */
+  @action
+  toggle() {
+    this.expanded = !this.expanded;
+  }
+
   expand() {
     if (this.parent) {
       this.parent.expand();

--- a/src/services/models/Operation.ts
+++ b/src/services/models/Operation.ts
@@ -86,7 +86,7 @@ export class OperationModel implements IMenuItem {
     parent: GroupModel | undefined,
     private options: RedocNormalizedOptions,
     isCallback: boolean = false,
-    callbackEventName: string | undefined = undefined,
+    callbackEventName?: string,
   ) {
     this.pointer = JsonPointer.compile(['paths', operationSpec.pathName, operationSpec.httpVerb]);
 

--- a/src/services/models/index.ts
+++ b/src/services/models/index.ts
@@ -1,3 +1,4 @@
+export * from './Callback';
 export * from '../SpecStore';
 export * from './Group.model';
 export * from './Operation';


### PR DESCRIPTION
# Description
This PR utilizes the code from https://github.com/Redocly/redoc/pull/757 written by @Makashov to add callback support to ReDoc. It further adds to the code by adding the following:
- Adds `isCallback: boolean` field to the `OperationModel` class in order to distinguish a normal `Operation` from a `Callback`. This defaults to `false`.
- `Callback`s are defined with the following behavior as a type of `Operation`:
   - `Callback`s by default will use the `event name` for the view's label when rendered by ReDoc, as opposed to the `operationID`.
   - `Callback`s by default _do not inherit_ the specification's global `security` definition(s). They default to having no security, and can have security added on an individual basis.
   - `Callback`s by default _do inherit_ the specification's global `servers` definition(s). In many cases, this can be undesirable. Override the `servers` property on individual callbacks to remedy this if needed.
- Adds some tests to maintain code coverage.
- The rendering style of a callback is meant to mimic that of an operation within an operation response dropdown.