### PR TITLE
Support for required additionalProperties

### DIFF
--- a/demo/openapi.yaml
+++ b/demo/openapi.yaml
@@ -398,10 +398,16 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties:
-                  type: integer
-                  format: int32
+                allOf:
+                  - type: object
+                    additionalProperties:
+                      x-additionalPropertiesName: status
+                      type: integer
+                      format: int32
+                  - required:
+                    - inStock
+                    - soldOut
+
       security:
         - api_key: []
   /store/order:

--- a/src/common-elements/fields.ts
+++ b/src/common-elements/fields.ts
@@ -45,6 +45,16 @@ export const RequiredLabel = styled(FieldLabel.withComponent('div'))`
   line-height: 1;
 `;
 
+export const RequiredImplicitFieldName = styled(FieldLabel.withComponent('div'))`
+  line-height: 20px;
+  white-space: nowrap;
+  font-size: 1em;
+  font-family: ${props => props.theme.typography.code.fontFamily};
+  font-style: normal;
+  font-weight: normal;
+  margin-left: 20px;
+`;
+
 export const RecursiveLabel = styled(FieldLabel)`
   color: ${({ theme }) => theme.colors.warning.main};
   font-size: 13px;

--- a/src/components/Fields/Field.tsx
+++ b/src/components/Fields/Field.tsx
@@ -1,7 +1,11 @@
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
-import { ClickablePropertyNameCell, RequiredLabel } from '../../common-elements/fields';
+import {
+  ClickablePropertyNameCell,
+  RequiredImplicitFieldName,
+  RequiredLabel,
+} from '../../common-elements/fields';
 import { FieldDetails } from './FieldDetails';
 
 import {
@@ -34,7 +38,7 @@ export class Field extends React.Component<FieldProps> {
   };
   render() {
     const { className, field, isLast } = this.props;
-    const { name, expanded, deprecated, required, kind } = field;
+    const { name, expanded, deprecated, required, requiredNames, kind } = field;
     const withSubSchema = !field.schema.isPrimitive && !field.schema.isCircular;
 
     const paramName = withSubSchema ? (
@@ -53,6 +57,13 @@ export class Field extends React.Component<FieldProps> {
       <PropertyNameCell className={deprecated ? 'deprecated' : undefined} kind={kind} title={name}>
         <PropertyBullet />
         {name}
+        {requiredNames && (
+          requiredNames.map((value, idx) => {
+            return (
+              <RequiredImplicitFieldName key={idx}> {value} </RequiredImplicitFieldName>
+            );
+          })
+        )}
         {required && <RequiredLabel> required </RequiredLabel>}
       </PropertyNameCell>
     );

--- a/src/components/__tests__/__snapshots__/DiscriminatorDropdown.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DiscriminatorDropdown.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Components SchemaView discriminator should correctly render discriminat
           "kind": "field",
           "name": "packSize",
           "required": false,
+          "requiredNames": undefined,
           "schema": SchemaModel {
             "activeOneOf": 0,
             "constraints": Array [],
@@ -65,6 +66,7 @@ exports[`Components SchemaView discriminator should correctly render discriminat
           "kind": "field",
           "name": "type",
           "required": true,
+          "requiredNames": undefined,
           "schema": SchemaModel {
             "activeOneOf": 0,
             "constraints": Array [],

--- a/src/services/models/Field.ts
+++ b/src/services/models/Field.ts
@@ -35,6 +35,7 @@ export class FieldModel {
   schema: SchemaModel;
   name: string;
   required: boolean;
+  requiredNames?: string[];
   description: string;
   example?: string;
   deprecated: boolean;
@@ -57,6 +58,7 @@ export class FieldModel {
     this.name = infoOrRef.name || info.name;
     this.in = info.in;
     this.required = !!info.required;
+    this.requiredNames = info.requiredNames;
 
     let fieldSchema = info.schema;
     let serializationMime = '';

--- a/src/types/open-api.d.ts
+++ b/src/types/open-api.d.ts
@@ -84,6 +84,7 @@ export interface OpenAPIParameter {
   in?: OpenAPIParameterLocation;
   description?: string;
   required?: boolean;
+  requiredNames?: string[];
   deprecated?: boolean;
   allowEmptyValue?: boolean;
   style?: OpenAPIParameterStyle;

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -114,6 +114,9 @@ export function isPrimitiveType(schema: OpenAPISchema, type: string | undefined 
   }
 
   if (type === 'object') {
+    if (schema.required !== undefined && schema.required.length !== 0) {
+      return false;
+    }
     return schema.properties !== undefined
       ? Object.keys(schema.properties).length === 0
       : schema.additionalProperties === undefined;


### PR DESCRIPTION
This fixes #1086 

When resulting schema contains `required` fields, that are not explicitly listed in schema - they must be covered by `additionalProperties` (because openapi does not support `patternProperties`) schema (if any) or are just `{}`.

The point is in listing these names, because validation will fail without them