### PR TITLE
Add "serve and watch" documentation for Docker image

### DIFF
--- a/config/docker/README.md
+++ b/config/docker/README.md
@@ -12,6 +12,12 @@ Serve local file:
     docker run -it --rm -p 80:80 \
       -v $(pwd)/demo/swagger.yaml:/usr/share/nginx/html/swagger.yaml \
       -e SPEC_URL=swagger.yaml redocly/redoc
+      
+Serve local file and watch for updates:
+
+    docker run -it --rm -p 80:80 \
+      -v $(pwd)/demo/:/usr/share/nginx/html/swagger/ \
+      -e SPEC_URL=swagger/swagger.yaml redocly/redoc
 
 ## Runtime configuration options
 


### PR DESCRIPTION
After spending some time figuring it out and finding [this issue](https://github.com/Redocly/redoc/issues/893), I was able to find how to watch files served by redoc via Docker. I'd like to save new developers time with this PR.