### PR TITLE
feat(cli): add the --title option to the serve subcommand

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -50,6 +50,11 @@ YargsParser.command(
       describe: 'path or URL to your spec',
     });
 
+    yargs.options('title', {
+      describe: 'Page Title',
+      type: 'string',
+    });
+
     yargs.option('s', {
       alias: 'ssr',
       describe: 'Enable server-side rendering',
@@ -73,6 +78,7 @@ YargsParser.command(
   async argv => {
     const config: Options = {
       ssr: argv.ssr as boolean,
+      title: argv.title as string,
       watch: argv.watch as boolean,
       templateFileName: argv.template as string,
       templateOptions: argv.templateOptions || {},


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/Redocly/redoc/pull/1073#issuecomment-577328022), the `--title` option was never implemented for the `serve` subcommand.

Here are my 3 test cases to show that it works: 

### No title provided
###### OpenAPI Spec
```yml
openapi: 3.0.0
info: {}
  # title: Title omitted from the file
paths: {}
```
###### Command
```sh
redoc-cli serve spec.yml
```
###### Expected title
ReDoc Documentation

###  Title provided in the file
###### OpenAPI Spec
```yml
openapi: 3.0.0
info:
  title: Title given in the file
paths: {}
```
###### Command
```sh
redoc-cli serve spec.yml
```
###### Expected title
Title given in the file

### Title provided to the command
###### OpenAPI Spec
```yml
openapi: 3.0.0
info: {}
  # title: Title omitted from the file
paths: {}
```
###### Command
```sh
redoc-cli serve spec.yml --title "Title given to the command"
```
###### Expected title
Title given to the command

### Title provided in the file and to the command
###### OpenAPI Spec
```yml
openapi: 3.0.0
info:
  title: Title given in the file
paths: {}
```
###### Command
```sh
redoc-cli serve spec.yml --title "Title given to the command"
```
###### Expected title
Title given to the command
