### PR TITLE
demo: new URL for GraphHopper

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -7,16 +7,10 @@ import ComboBox from './ComboBox';
 
 const demos = [
   { value: 'https://api.apis.guru/v2/specs/instagram.com/1.0.0/swagger.yaml', label: 'Instagram' },
-  {
-    value: 'https://api.apis.guru/v2/specs/googleapis.com/calendar/v3/swagger.yaml',
-    label: 'Google Calendar',
-  },
+  { value: 'https://api.apis.guru/v2/specs/googleapis.com/calendar/v3/swagger.yaml', label: 'Google Calendar' },
   { value: 'https://api.apis.guru/v2/specs/slack.com/1.2.0/swagger.yaml', label: 'Slack' },
   { value: 'https://api.apis.guru/v2/specs/zoom.us/2.0.0/swagger.yaml', label: 'Zoom.us' },
-  {
-    value: 'https://api.apis.guru/v2/specs/graphhopper.com/1.0/swagger.yaml',
-    label: 'GraphHopper',
-  },
+  { value: 'https://docs.graphhopper.com/openapi.json', label: 'GraphHopper' },
 ];
 
 const DEFAULT_SPEC = 'openapi.yaml';


### PR DESCRIPTION
Not sure if this is wanted, but [we have now a spec](https://github.com/graphhopper/directions-api-doc/) that we use in production and uses several features of redoc. See [preview](http://redocly.github.io/redoc/?url=https://docs.graphhopper.com/openapi.json).