### PR TITLE
Add field caching to avoid out of memory exception.

### DIFF
--- a/src/services/models/Schema.ts
+++ b/src/services/models/Schema.ts
@@ -275,12 +275,17 @@ export class SchemaModel {
   }
 }
 
+const fieldCache: { [index: string]: FieldModel[] } = {};
+
 function buildFields(
   parser: OpenAPIParser,
   schema: OpenAPISchema,
   $ref: string,
   options: RedocNormalizedOptions,
 ): FieldModel[] {
+  if (fieldCache[$ref]) {
+    return fieldCache[$ref];
+  }
   const props = schema.properties || {};
   const additionalProps = schema.additionalProperties;
   const defaults = schema.default || {};
@@ -338,6 +343,8 @@ function buildFields(
       ),
     );
   }
+
+  fieldCache[$ref] = fields;
 
   return fields;
 }


### PR DESCRIPTION
Hey Roman.

I made a quick-fix be able to render our API documentation to not hit an out-of-memory exception (or browser crash).

The only change I did is to implement some caching of the affected field. Maybe it helps to fix this issue:
https://github.com/Redocly/redoc/issues/696

Here is the OpenApi spec we use to generate the docs.
https://raw.githubusercontent.com/Picturepark/Picturepark.SDK.DotNet/master/swagger/PictureparkSwagger.json