### PR TITLE
fix: do not collapse top level on Collapse All in json samples

### DIFF
--- a/src/components/JsonViewer/JsonViewer.tsx
+++ b/src/components/JsonViewer/JsonViewer.tsx
@@ -58,7 +58,7 @@ class Json extends React.PureComponent<JsonProps> {
   collapseAll = () => {
     const elements = this.node.getElementsByClassName('collapsible');
     // skip first item to avoid collapsing whole object/array
-    const elementsArr = Array.prototype.slice.call(elements).slice(1);
+    const elementsArr = Array.prototype.slice.call(elements, 1);
 
     for (const expanded of elementsArr) {
       (expanded.parentNode as Element)!.classList.add('collapsed');

--- a/src/components/JsonViewer/JsonViewer.tsx
+++ b/src/components/JsonViewer/JsonViewer.tsx
@@ -57,11 +57,10 @@ class Json extends React.PureComponent<JsonProps> {
 
   collapseAll = () => {
     const elements = this.node.getElementsByClassName('collapsible');
-    for (const expanded of Array.prototype.slice.call(elements)) {
-      // const collapsed = elements[i];
-      if ((expanded.parentNode as Element)!.classList.contains('redoc-json')) {
-        continue;
-      }
+    // skip first item to avoid collapsing whole object/array
+    const elementsArr = Array.prototype.slice.call(elements).slice(1);
+
+    for (const expanded of elementsArr) {
       (expanded.parentNode as Element)!.classList.add('collapsed');
     }
   };


### PR DESCRIPTION
This PR updates the` collapseAll` method to avoid collapsing whole object/array in JSON preview.

Fixes #1164