### PR TITLE
fix: sort discriminator entries by mapping order

### DIFF
--- a/src/services/models/Schema.ts
+++ b/src/services/models/Schema.ts
@@ -283,7 +283,7 @@ export class SchemaModel {
 
         if (indexLeft < 0 && indexRight < 0) {
           // out of mapping, order by name
-          return left.name - right.name;
+          return left.name.localCompare(right.name);
         } else if (indexLeft < 0) {
           // the right is found, so mapping wins
           return 1;

--- a/src/services/models/Schema.ts
+++ b/src/services/models/Schema.ts
@@ -254,7 +254,7 @@ export class SchemaModel {
 
     const inversedMapping = { ...implicitInversedMapping, ...explicitInversedMapping };
 
-    const refs: Array<{ $ref; name }> = [];
+    let refs: Array<{ $ref; name }> = [];
 
     for (const $ref of Object.keys(inversedMapping)) {
       const names = inversedMapping[$ref];
@@ -265,6 +265,35 @@ export class SchemaModel {
       } else {
         refs.push({ $ref, name: names });
       }
+    }
+
+    // Make the listing respects the mapping 
+    // in case a mapping is defined, the user usually wants to have the order shown
+    // as it was defined in the yaml. This will sort the names given the provided
+    // mapping (if provided).
+    // The logic is:
+    // - If a name is among the mapping, promote it to first
+    // - Names among the mapping are sorted by their order in the mapping
+    // - Names outside the mapping are sorted alphabetically
+    const names = Object.keys(mapping);
+    if (names.length !== 0) {
+      refs = refs.sort((left, right) => {
+        const indexLeft = names.indexOf(left.name);
+        const indexRight = names.indexOf(right.name);
+
+        if (indexLeft < 0 && indexRight < 0) {
+          // out of mapping, order by name
+          return left.name - right.name;
+        } else if (indexLeft < 0) {
+          // the right is found, so mapping wins
+          return 1;
+        } else if (indexRight < 0) {
+          // left wins as it's in mapping
+          return -1;
+        } else {
+          return indexLeft - indexRight;
+        }
+      });
     }
 
     this.oneOf = refs.map(({ $ref, name }) => {


### PR DESCRIPTION
The fix for #1111 (in https://github.com/Redocly/redoc/commit/6e390f9c7909da0b5d1d6fc571ab4ad92e715d6e) sadly broke the order of mapping entries.
Given the discriminator:
```yaml
      discriminator:
        propertyName: petType
        x-limitToMapping: true
        mapping:
          dog: "#/components/schemas/Dog"
          cat: "#/components/schemas/Cat"
          doggy: "#/components/schemas/Dog"
          bee: "#/components/schemas/HoneyBee
```
The result is out of order:
![image](https://user-images.githubusercontent.com/270342/77674750-562b3c00-6f8c-11ea-97ca-aaa6924d7d63.png)
Also, if we remove the `Dog` mappings, we end up with the `Dog` class between the mappings:
![image](https://user-images.githubusercontent.com/270342/77674959-9f7b8b80-6f8c-11ea-9c53-2dea1c97297d.png)

This PR adds a sort in case of the presence of a mapping. The behavior is quite simple:
- Explicit mappings are prioritized to implicit mappings
  ```yaml
      discriminator:
        propertyName: petType
        x-limitToMapping: true
        mapping:
          dog: "#/components/schemas/Dog"
          cat: "#/components/schemas/Cat"
          doggy: "#/components/schemas/Dog"
          bee: "#/components/schemas/HoneyBee"
  ```
  gives
  ![image](https://user-images.githubusercontent.com/270342/77675726-9808b200-6f8d-11ea-824a-2aa23fa9bb01.png)

- Explicit mappings are sorted by the order they were defined in the mapping
- Implicit mappings are sorted alphabetically among themselves
  ```yaml
      discriminator:
        propertyName: petType
        x-limitToMapping: true
        mapping:
          cat: "#/components/schemas/Cat"
  ```
  ![image](https://user-images.githubusercontent.com/270342/77675396-2e88a380-6f8d-11ea-802d-7693ec7f1447.png) 
In case no mapping is defined, the default behavior is kept.



