### PR TITLE
Remove core-js/promise bundle into worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9616,7 +9616,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
                 }
@@ -16467,7 +16468,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
                 }
@@ -17565,7 +17567,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
                 }

--- a/src/services/SearchWorker.worker.ts
+++ b/src/services/SearchWorker.worker.ts
@@ -1,12 +1,5 @@
 import * as lunr from 'lunr';
 
-try {
-  // tslint:disable-next-line
-  require('core-js/es/promise'); // bundle into worker
-} catch (_) {
-  // nope
-}
-
 /* just for better typings */
 export default class Worker {
   add: typeof add = add;


### PR DESCRIPTION
I had an issue with core-js/es/promise as it was unable to resolve. Looking at the code, I thought we could do away with this.  Just my thought..