### PR TITLE
Add security headers to nginx config

### DIFF
--- a/config/docker/nginx.conf
+++ b/config/docker/nginx.conf
@@ -17,6 +17,13 @@ http {
     server_name       localhost;
     index             index.html index.htm;
 
+    # Add security headers
+    add_header X-Frame-Options deny always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Content-Security-Policy "default-src 'none'" always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+
     location / {
       alias            /usr/share/nginx/html/;
 

--- a/config/docker/nginx.conf
+++ b/config/docker/nginx.conf
@@ -17,17 +17,18 @@ http {
     server_name       localhost;
     index             index.html index.htm;
 
-    # Add security headers
-    add_header X-Frame-Options deny always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header X-Content-Type-Options nosniff always;
-    add_header Content-Security-Policy "default-src 'none'" always;
-    add_header Referrer-Policy strict-origin-when-cross-origin always;
-
     location / {
       alias            /usr/share/nginx/html/;
 
       if ($request_method = 'OPTIONS') {
+          # Add security headers
+          add_header 'X-Frame-Options' 'deny always';
+          add_header 'X-XSS-Protection' '"1; mode=block" always';
+          add_header 'X-Content-Type-Options' 'nosniff always';
+          add_header 'Content-Security-Policy' '"default-src \'none\'" always';
+          add_header 'Referrer-Policy' 'strict-origin-when-cross-origin always';
+
+          # Set access control header
           add_header 'Access-Control-Allow-Origin' '*';
           add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
           #
@@ -43,11 +44,27 @@ http {
           return 204;
       }
       if ($request_method = 'POST') {
+          # Add security headers
+          add_header 'X-Frame-Options' 'deny always';
+          add_header 'X-XSS-Protection' '"1; mode=block" always';
+          add_header 'X-Content-Type-Options' 'nosniff always';
+          add_header 'Content-Security-Policy' '"default-src \'none\'" always';
+          add_header 'Referrer-Policy' 'strict-origin-when-cross-origin always';
+
+          # Set access control header
           add_header 'Access-Control-Allow-Origin' '*';
           add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
           add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
       }
       if ($request_method = 'GET') {
+          # Add security headers
+          add_header 'X-Frame-Options' 'deny always';
+          add_header 'X-XSS-Protection' '"1; mode=block" always';
+          add_header 'X-Content-Type-Options' 'nosniff always';
+          add_header 'Content-Security-Policy' '"default-src \'none\'" always';
+          add_header 'Referrer-Policy' 'strict-origin-when-cross-origin always';
+
+          # Set access control header
           add_header 'Access-Control-Allow-Origin' '*';
           add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
           add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';

--- a/config/docker/nginx.conf
+++ b/config/docker/nginx.conf
@@ -25,8 +25,7 @@ http {
           add_header 'X-Frame-Options' 'deny always';
           add_header 'X-XSS-Protection' '"1; mode=block" always';
           add_header 'X-Content-Type-Options' 'nosniff always';
-          add_header 'Content-Security-Policy' '"default-src \'none\'" always';
-          add_header 'Referrer-Policy' 'strict-origin-when-cross-origin always';
+          add_header 'Referrer-Policy' 'strict-origin-when-cross-origin';
 
           # Set access control header
           add_header 'Access-Control-Allow-Origin' '*';
@@ -48,8 +47,7 @@ http {
           add_header 'X-Frame-Options' 'deny always';
           add_header 'X-XSS-Protection' '"1; mode=block" always';
           add_header 'X-Content-Type-Options' 'nosniff always';
-          add_header 'Content-Security-Policy' '"default-src \'none\'" always';
-          add_header 'Referrer-Policy' 'strict-origin-when-cross-origin always';
+          add_header 'Referrer-Policy' 'strict-origin-when-cross-origin';
 
           # Set access control header
           add_header 'Access-Control-Allow-Origin' '*';
@@ -61,8 +59,7 @@ http {
           add_header 'X-Frame-Options' 'deny always';
           add_header 'X-XSS-Protection' '"1; mode=block" always';
           add_header 'X-Content-Type-Options' 'nosniff always';
-          add_header 'Content-Security-Policy' '"default-src \'none\'" always';
-          add_header 'Referrer-Policy' 'strict-origin-when-cross-origin always';
+          add_header 'Referrer-Policy' 'strict-origin-when-cross-origin';
 
           # Set access control header
           add_header 'Access-Control-Allow-Origin' '*';


### PR DESCRIPTION
Increase the security of the nginx server and the served page, by adding the following security headers to the nginx config:
- X-Frame-Options (Disables click jacking by disallowing the page to be run in a frame/iframe)
- X-XSS-Protection (Enables cross site scripting filtering)
- X-Content-Type-Options (Disables MIME sniffing and forces browser to use the type given in Content-Type.)
- Content-Security-Policy (Controls resources the user agent is allowed to load for a given page.)
- Referrer-Policy (Governs which referrer information sent in the Referer header should be included with requests made.)

Additional headers that could be added optionally:
- Strict-Transport-Security (Enforce HTTPS over HTTP)