### PR TITLE
Updated x-servers link to point to valid location.

### DIFF
--- a/docs/redoc-vendor-extensions.md
+++ b/docs/redoc-vendor-extensions.md
@@ -4,7 +4,7 @@ ReDoc makes use of the following [vendor extensions](https://swagger.io/specific
 ### Swagger Object vendor extensions
 Extend OpenAPI root [Swagger Object](https://swagger.io/specification/#oasObject)
 #### x-servers
-Backported from OpenAPI 3.0 [`servers`](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.0.md#server-object). Currently doesn't support templates.
+Backported from OpenAPI 3.0 [`servers`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#serverObject). Currently doesn't support templates.
 
 #### x-tagGroups
 


### PR DESCRIPTION
The file `docs/redoc-vendor-extensions.md` contained a link to `https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.0.md#server-object`, which is invalid. I updated it to point to `https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#serverObject`