### PR TITLE
Prevent body scrolling when user scrolls side menu

### DIFF
--- a/src/common-elements/perfect-scrollbar.tsx
+++ b/src/common-elements/perfect-scrollbar.tsx
@@ -80,6 +80,7 @@ export function PerfectScrollbarWrap(
           <div
             style={{
               overflow: 'auto',
+              overscrollBehavior: 'contain',
               msOverflowStyle: '-ms-autohiding-scrollbar',
             }}
           >


### PR DESCRIPTION
Added [`overscroll-behavior: contain`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior) to side menu when native scrollbars used. It will prevent body scrolling when user scrolls over menu using mouse wheel or trackpad.