### PR TITLE
add Array size info based on min max Items properties

### DIFF
--- a/src/components/Schema/ArraySchema.tsx
+++ b/src/components/Schema/ArraySchema.tsx
@@ -4,6 +4,7 @@ import { Schema, SchemaProps } from './Schema';
 
 import { ArrayClosingLabel, ArrayOpenningLabel } from '../../common-elements';
 import styled from '../../styled-components';
+import {humanizeConstraints} from "../../utils";
 
 const PaddedSchema = styled.div`
   padding-left: ${({ theme }) => theme.spacing.unit * 2}px;
@@ -12,9 +13,16 @@ const PaddedSchema = styled.div`
 export class ArraySchema extends React.PureComponent<SchemaProps> {
   render() {
     const itemsSchema = this.props.schema.items!;
+    const itemConstraintSchema = (
+      min: number | undefined = undefined,
+      max: number | undefined = undefined,
+    ) => ({ type: 'array', minItems: min, maxItems: max });
+
+    const minMaxItems = humanizeConstraints(itemConstraintSchema(itemsSchema.schema.minItems, itemsSchema.schema.maxItems));
+
     return (
       <div>
-        <ArrayOpenningLabel> Array </ArrayOpenningLabel>
+        <ArrayOpenningLabel> Array ({minMaxItems})</ArrayOpenningLabel>
         <PaddedSchema>
           <Schema {...this.props} schema={itemsSchema} />
         </PaddedSchema>


### PR DESCRIPTION
Encountered [this issue](https://github.com/Redocly/redoc/issues/1131) in our spec, trying to fix according to suggestion in issue.

This is my first attempt to contribute to redoc (or any TypeScript/JavaScript project) - I hope I'm in the right direction, but I can't seem to build the project locally - tests are failing (on a clean master repo), so please be gentle.

If you can point me to how to add a test for this behavior, I'll gladly do that too.