### PR TITLE
 Updating Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ## Releases
 **Important:** all the **2.x** releases are deployed to npm and can be used via jsdeliver:
-- particular release, e.g. `v2.0.0-alpha.15`: https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js
+- particular release, e.g. `v2.0.0-alpha.17`: https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js
 - `next` release: https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js
 
 Additionally, all the 1.x releases are hosted on our GitHub Pages-based CDN **(deprecated)**:

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Redoc.init('http://petstore.swagger.io/v2/swagger.json', {
 -----------
 
 ## Join Us
-WE'RE HIRING! Love APIs and working with distributed systems? Learn more about our [open positions](https://redoc.ly/careers)
+WE'RE HIRING! Love APIs and working with distributed teams? Learn more about our [open positions](https://redoc.ly/careers)
 
 ## Development
 see [CONTRIBUTING.md](.github/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -298,9 +298,9 @@ Redocly has a variety of products, this table shows an overview of all Redocly p
 | Redoc | The API reference documentation output from the OpenAPI definition. This edition has limited functionality.  | Community Edition |
 | create-openapi-repo   | CLI tool for splitting a single OpenAPI definition file into multiple files, start a new API definition, validating your OpenAPI definition, and other features. | Community Edition  |
 | openapi-cli  | CLI tool that provides linting against a customizable rules, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool. | Community Edition  |
-| API Reference Docs | The premium version of Redoc – the API reference documentation output from the OpenAPI definition file. This premium version includes `Try-it functionality`, `enhanced search`, `fast loading`, `special tags`, and other advanced features. | Premium Editon  |
-| Developer Portal (beta)  | A sample `starter` developer portal, built on top of Gatsby. Intended for more robust documentation such as landing pages, how-to guides, tutorials and so much more. | Premium Editon  |
-| Workflows | An online Redocly app that provides the full authoring and publishing toolset in the cloud, with GitHub, Gitlab, Azure and Bitbucket integration and docs-as-code worflows. | Premium Editon |
+| API Reference Docs | The premium version of Redoc – the API reference documentation output from the OpenAPI definition file. This premium version includes `Try-it functionality`, `enhanced search`, `fast loading`, `special tags`, and other advanced features. | Premium Edition  |
+| Developer Portal (beta)  | A sample `starter` developer portal, built on top of Gatsby. Intended for more robust documentation such as landing pages, how-to guides, tutorials and so much more. | Premium Edition  |
+| Workflows | An online Redocly app that provides the full authoring and publishing toolset in the cloud, with GitHub, Gitlab, Azure and Bitbucket integration and docs-as-code worflows. | Premium Edition |
 
 ## Join Us
 **WE'RE HIRING!** Love APIs and working with distributed teams? Learn more about our [open positions](https://redoc.ly/careers)

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 [ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition into **zero-dependency** HTML file. It can be installed as a development dependency in your project.
 
 ## Create-openapi-repo
-[Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files organized in folders **compatible with version 3x only**. You can also use this tool to start a new API definition and validate your OpenAPI definition.
+[Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files organized in folders. You can also use this tool to start a new API definition and validate your OpenAPI definition.
 
 ## Community Edition(CE) vs Premium Edition(PE)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Features
 - Extremely easy deployment
-- [redoc-cli](https://github.com/Redocly/redoc/blob/master/cli/README.md) with ability to bundle your docs into **zero-dependency** HTML file
+- [Redoc-cli](https://github.com/Redocly/redoc/blob/master/cli/README.md) with ability to bundle your docs into **zero-dependency** HTML file
 - Server Side Rendering ready
 - The widest OpenAPI v2.0 features support (yes, it supports even `discriminator`) <br>
 ![](docs/images/discriminator-demo.gif)
@@ -203,7 +203,7 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 [ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition(s) into **zero-dependency** HTML file. It can be installed as a development dependency in your project.
 
 ## Create-openapi-repo
-[Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files (compatible with version 3x only). You can also use this tool to start a new API definition.
+[Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files **compatible with version 3x only**. You can also use this tool to start a new API definition.
 
 ## Community Edition(CE) vs Premium Edition(PE)
 
@@ -289,13 +289,13 @@ Redoc.init('http://petstore.swagger.io/v2/swagger.json', {
 
 -----------
 
-## Redocly products
+## Redocly Products
 
 Redocly has a variety of products, this table shows an overview of all Redocly products.
 
-| Tools       | Description     | Edition    |
-| :------------- | ---------- | ----------- |
-|  Redoc | The API reference documentation output from the OpenAPI definition. This free version has limited functionality.  | Community Edition |
+| Tools   | Description     | Edition    |
+| :------------- | :---------- | :----------- |
+| Redoc | The API reference documentation output from the OpenAPI definition. This free version has limited functionality.  | Community Edition |
 | create-openapi-repo   | CLI tool for splitting a single OpenAPI definition file into multiple files (compatible with version 3x only). You can also use this CLI tool to start a new API definition. | Community Edition  |
 | openapi-cli  | CLI tool that provides linting against a customizable ruleset, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool. | Community Edition  |
 | Redocly API Reference   | The premium version of Redoc – the API reference documentation output from the OpenAPI definition file. This premium version includes Try-it functionality, enhanced search, fast loading, special tags, and other features. | Premium Editon  |

--- a/README.md
+++ b/README.md
@@ -306,4 +306,4 @@ Redocly has a variety of products, this table shows an overview of all Redocly p
 **WE'RE HIRING!** Love APIs and working with distributed teams? Learn more about our [open positions](https://redoc.ly/careers)
 
 ## Development
-see [CONTRIBUTING.md](.github/CONTRIBUTING.md)
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Redocly has a variety of products, this table shows an overview of all Redocly p
 | create-openapi-repo   | CLI tool for splitting a single OpenAPI definition file into multiple files, start a new API definition, validating your OpenAPI definition, and other features. | Community Edition  |
 | openapi-cli  | CLI tool that provides linting against a customizable rules, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool. | Community Edition  |
 | API Reference Docs | The premium version of Redoc – the API reference documentation output from the OpenAPI definition file. This premium version includes `Try-it functionality`, `enhanced search`, `fast loading`, `special tags`, and other advanced features. | Premium Edition  |
-| Developer Portal (beta)  | A sample `starter` developer portal, built on top of Gatsby. Intended for more robust documentation such as landing pages, how-to guides, tutorials and so much more. | Premium Edition  |
+| Developer Portal (beta)  | A sample `starter` developer portal, built on top of Gatsby. Intended for more robust documentation such as `landing pages`, `how-to guides`, `tutorials` and so much more. | Premium Edition  |
 | Workflows | An online Redocly app that provides the full authoring and publishing toolset in the cloud, with GitHub, Gitlab, Azure and Bitbucket integration and docs-as-code worflows. | Premium Edition |
 
 ## Join Us

--- a/README.md
+++ b/README.md
@@ -207,13 +207,13 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 Redocly offers two different editions: the [Community Edition (CE)](https://redoc.ly/redoc) and the [Premium Edition (PE)](https://redoc.ly/pricing). They offer the same easily deployable API documentation, on your website, fully supporting OpenAPI v2 and OpenAPI v3., but the difference is the limited features which is only available in the Premium Edition.
 
 The **Redocly CE** is free and open source and is aimed at developers and teams who are looking to create easily deployable API documentation. The **Redocly CE** benefits are:
-* [Redoc](https://redoc.ly/redoc) Simple to set up: No server required and fully customizable theme.
-* [Openapi-cli](https://redoc.ly/openapi-cli)validate a multi-file OpenAPI definition
+* [Redoc](https://redoc.ly/redoc) simple to set up: no server required and fully customizable theme.
+* [Openapi-cli](https://redoc.ly/openapi-cli) validate a multi-file OpenAPI definition
 
 The **Redocly PE** comes in the starter versions and the paid versions. The **Redocly PE** benefits are:
-* [Reference documentation](https://redoc.ly/reference-docs) Easily create, style, and manage your API documentation with advanced developer friendly features
-* [Developer Portal (Beta)](https://redoc.ly/developer-portal) Where docs-as-code meets docs-as-marketing
-* [Workflows](https://redoc.ly/workflows) Build, maintain, and automatically update your API documentation in the cloud
+* [Reference documentation](https://redoc.ly/reference-docs) easily create, style, and manage your API documentation with advanced developer friendly features
+* [Developer Portal (Beta)](https://redoc.ly/developer-portal) where docs-as-code meets docs-as-marketing
+* [Workflows](https://redoc.ly/workflows) build, maintain, and automatically update your API documentation in the cloud
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,10 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 
 ## ReDoc CLI
 
-[See here](https://github.com/Redocly/redoc/blob/master/cli/README.md)
+[ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) can be installed as a development dependency in your project to generate documentation for your API specification
+
+## create-openapi-repo
+[create-openapi-repo](https://github.com/Redocly/create-openapi-repo) `cli` tool is used for splitting a single OpenAPI definition file into multiple files (compatible with version 3x only). You can also use this `cli` tool to start a new API definition.
 
 ## Community Edition(CE) vs Premium Edition(PE)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Features
 - Extremely easy deployment
-- [Redoc-cli](https://github.com/Redocly/redoc/blob/master/cli/README.md) with ability to bundle your docs into **zero-dependency** HTML file
+- [redoc-cli](https://github.com/Redocly/redoc/blob/master/cli/README.md) with ability to bundle your docs into **zero-dependency** HTML file
 - Server Side Rendering ready
 - The widest OpenAPI v2.0 features support (yes, it supports even `discriminator`) <br>
 ![](docs/images/discriminator-demo.gif)
@@ -200,7 +200,7 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 
 ## ReDoc CLI
 
-[ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition into **zero-dependency** HTML file. It can be installed as a development dependency in your project.
+[redoc-cli](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition into **zero-dependency** HTML file. It can be installed as a development dependency in your project.
 
 ## Generator for GH repo
 [create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files organized in folders. You can also use this tool to start a new API definition and validate your OpenAPI definition.

--- a/README.md
+++ b/README.md
@@ -203,21 +203,21 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 [ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition(s) into **zero-dependency** HTML file. It can be installed as a development dependency in your project.
 
 ## Create-openapi-repo
-[Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files **compatible with version 3x only**. You can also use this tool to start a new API definition.
+[Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files organized in folders **compatible with version 3x only**. You can also use this tool to start a new API definition and validate your OpenAPI definition.
 
 ## Community Edition(CE) vs Premium Edition(PE)
 
 Redocly offers two different editions: the [Community Edition (CE)](https://redoc.ly/redoc) and the [Premium Edition (PE)](https://redoc.ly/pricing). They offer the same easily deployable API documentation, fully supporting OpenAPI v2 and OpenAPI v3., but the difference is the limited features which is only available in the Premium Edition.
 
 The [Redocly CE](https://redoc.ly/redoc) is free and open source and is aimed at developers and teams who are looking to create easily deployable API documentation. The [Redocly CE](https://redoc.ly/redoc) products are:
-* [Redoc](https://redoc.ly/redoc): simple to set up: no server required and fully customizable theme.
-* [Openapi-cli](https://redoc.ly/openapi-cli): lint and bundle your OpenAPI definition(s)
+* [Redoc](https://redoc.ly/redoc): simple to set up, no server required and fully customizable theme.
+* [Openapi-cli](https://redoc.ly/openapi-cli): lint and bundle your OpenAPI definition(s).
 * [Create-openapi-repo](https://github.com/Redocly/create-openapi-repo): write and start a new OpenAPI definition.
 
 The [Redocly PE](https://redoc.ly/pricing) comes in the starter versions and the paid versions. The [Redocly PE](https://redoc.ly/pricing)products are:
-* [API Reference](https://redoc.ly/reference-docs): easily create, style, and manage your API documentation with advanced developer friendly features
-* [Developer Portal (Beta)](https://redoc.ly/developer-portal): where docs-as-code meets docs-as-marketing
-* [Workflows](https://redoc.ly/workflows): build, maintain, and automatically update your API documentation in the cloud
+* [API Reference Docs](https://redoc.ly/reference-docs): easily create, style, and manage your API documentation with advanced developer friendly features.
+* [Developer Portal (Beta)](https://redoc.ly/developer-portal): where docs-as-code meets docs-as-marketing.
+* [Workflows](https://redoc.ly/workflows): build, maintain, and automatically update your API documentation in the cloud.
 
 ## Configuration
 
@@ -295,12 +295,12 @@ Redocly has a variety of products, this table shows an overview of all Redocly p
 
 | Tools   | Description     | Edition    |
 | :------------- | :---------- | :----------- |
-| Redoc | The API reference documentation output from the OpenAPI definition. This free version has limited functionality.  | Community Edition |
-| create-openapi-repo   | CLI tool for splitting a single OpenAPI definition file into multiple files (compatible with version 3x only). You can also use this CLI tool to start a new API definition. | Community Edition  |
-| openapi-cli  | CLI tool that provides linting against a customizable ruleset, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool. | Community Edition  |
-| Redocly API Reference | The premium version of Redoc – the API reference documentation output from the OpenAPI definition file. This premium version includes Try-it functionality, enhanced search, fast loading, special tags, and other features. | Premium Editon  |
-| Developer Portal (beta)  | A sample `starter` developer portal, built on top of Gatsby. Intended for more robust documentation scenarios. | Premium Editon  |
-| Workflows | A online Redocly app that provides the full authoring and publishing toolset in the cloud, with GitHub integration and docs-as-code worflows | Premium Editon |
+| Redoc | The API reference documentation output from the OpenAPI definition. This edition has limited functionality.  | Community Edition |
+| create-openapi-repo   | CLI tool for splitting a single OpenAPI definition file into multiple files, start a new API definition, validating your OpenAPI definition, and other features. | Community Edition  |
+| openapi-cli  | CLI tool that provides linting against a customizable rules, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool. | Community Edition  |
+| API Reference Docs | The premium version of Redoc – the API reference documentation output from the OpenAPI definition file. This premium version includes Try-it functionality, enhanced search, fast loading, special tags, and other advanced features. | Premium Editon  |
+| Developer Portal (beta)  | A sample `starter` developer portal, built on top of Gatsby. Intended for more robust documentation such as landing pages, how-to guides, tutorials and so much more. | Premium Editon  |
+| Workflows | An online Redocly app that provides the full authoring and publishing toolset in the cloud, with GitHub, Gitlab, Azure and Bitbucket integration and docs-as-code worflows. | Premium Editon |
 
 ## Join Us
 **WE'RE HIRING!** Love APIs and working with distributed teams? Learn more about our [open positions](https://redoc.ly/careers)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
   - [ ] built-in API Console
 
 ## Releases
-**Important:** all the **2.x** releases are deployed to npm and can be used via jsdeliver:
+**Important:** all the **2.x** releases are deployed to `npm` and can be used via `jsdeliver`:
 - particular release, e.g. `v2.0.0-alpha.17`: https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js
 - `next` release: https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js
 

--- a/README.md
+++ b/README.md
@@ -200,24 +200,24 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 
 ## ReDoc CLI
 
-[ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition(s) into **zero-dependency** HTML file .It can be installed as a development dependency in your project.
+[ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition(s) into **zero-dependency** HTML file. It can be installed as a development dependency in your project.
 
 ## Create-openapi-repo
 [Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files (compatible with version 3x only). You can also use this tool to start a new API definition.
 
 ## Community Edition(CE) vs Premium Edition(PE)
 
-Redocly offers two different editions: the [Community Edition (CE)](https://redoc.ly/redoc) and the [Premium Edition (PE)](https://redoc.ly/pricing). They offer the same easily deployable API documentation, on your website, fully supporting OpenAPI v2 and OpenAPI v3., but the difference is the limited features which is only available in the Premium Edition.
+Redocly offers two different editions: the [Community Edition (CE)](https://redoc.ly/redoc) and the [Premium Edition (PE)](https://redoc.ly/pricing). They offer the same easily deployable API documentation, fully supporting OpenAPI v2 and OpenAPI v3., but the difference is the limited features which is only available in the Premium Edition.
 
-The **Redocly CE** is free and open source and is aimed at developers and teams who are looking to create easily deployable API documentation. The **Redocly CE** benefits are:
-* [Redoc](https://redoc.ly/redoc) simple to set up: no server required and fully customizable theme.
-* [Openapi-cli](https://redoc.ly/openapi-cli) lint and bundle your OpenAPI definition(s)
-* [Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) write and start a new OpenAPI definition.
+The **Redocly CE** is free and open source and is aimed at developers and teams who are looking to create easily deployable API documentation. The **Redocly CE** products are:
+* [Redoc](https://redoc.ly/redoc): simple to set up: no server required and fully customizable theme.
+* [Openapi-cli](https://redoc.ly/openapi-cli): lint and bundle your OpenAPI definition(s)
+* [Create-openapi-repo](https://github.com/Redocly/create-openapi-repo): write and start a new OpenAPI definition.
 
-The **Redocly PE** comes in the starter versions and the paid versions. The **Redocly PE** benefits are:
-* [Reference documentation](https://redoc.ly/reference-docs) easily create, style, and manage your API documentation with advanced developer friendly features
-* [Developer Portal (Beta)](https://redoc.ly/developer-portal) where docs-as-code meets docs-as-marketing
-* [Workflows](https://redoc.ly/workflows) build, maintain, and automatically update your API documentation in the cloud
+The **Redocly PE** comes in the starter versions and the paid versions. The **Redocly PE** products are:
+* [API Reference](https://redoc.ly/reference-docs): easily create, style, and manage your API documentation with advanced developer friendly features
+* [Developer Portal (Beta)](https://redoc.ly/developer-portal): where docs-as-code meets docs-as-marketing
+* [Workflows](https://redoc.ly/workflows): build, maintain, and automatically update your API documentation in the cloud
 
 ## Configuration
 
@@ -288,6 +288,19 @@ Redoc.init('http://petstore.swagger.io/v2/swagger.json', {
 ```
 
 -----------
+
+## Redocly products
+
+Redocly has a variety of products, this table shows an overview of all Redocly products.
+
+| Tools       | Description     | Edition    |
+| :------------- | ---------- | ----------- |
+|  Redoc | The API reference documentation output from the OpenAPI definition. This free version has limited functionality.  | Community Edition |
+| create-openapi-repo   | CLI tool for splitting a single OpenAPI definition file into multiple files (compatible with version 3x only). You can also use this CLI tool to start a new API definition. | Community Edition  |
+| openapi-cli  | CLI tool that provides linting against a customizable ruleset, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool. | Community Edition  |
+| Redocly API Reference   | The premium version of Redoc – the API reference documentation output from the OpenAPI definition file. This premium version includes Try-it functionality, enhanced search, fast loading, special tags, and other features. | Premium Editon  |
+| Developer Portal (beta)  | A sample “starter” developer portal, built on top of Gatsby. Intended for more robust documentation scenarios. | Premium Editon  |
+| Workflows | A online Redocly app that provides the full authoring and publishing toolset in the cloud, with GitHub integration and docs-as-code worflows | Premium Editon  |
 
 ## Join Us
 **WE'RE HIRING!** Love APIs and working with distributed teams? Learn more about our [open positions](https://redoc.ly/careers)

--- a/README.md
+++ b/README.md
@@ -202,6 +202,19 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 
 [See here](https://github.com/Redocly/redoc/blob/master/cli/README.md)
 
+## Community Edition(CE) vs Premium Edition(PE)
+
+Redocly offers two different editions: the [Community Edition (CE)](https://redoc.ly/redoc) and the [Premium Edition (PE)](https://redoc.ly/pricing). They offer the same easily deployable API documentation, on your website, fully supporting OpenAPI v2 and OpenAPI v3., but the difference is the limited features which is only available in the Premium Edition.
+
+The **Redocly CE** is free and open source and is aimed at developers and teams who are looking to create easily deployable API documentation. The **Redocly CE** benefits are:
+* [Redoc](https://redoc.ly/redoc) Simple to set up: No server required and fully customizable theme.
+* [Openapi-cli](https://redoc.ly/openapi-cli)validate a multi-file OpenAPI definition
+
+The **Redocly PE** comes in the starter versions and the paid versions. The **Redocly PE** benefits are:
+* [Reference documentation](https://redoc.ly/reference-docs) Easily create, style, and manage your API documentation with advanced developer friendly features
+* [Developer Portal (Beta)](https://redoc.ly/developer-portal) Where docs-as-code meets docs-as-marketing
+* [Workflows](https://redoc.ly/workflows) Build, maintain, and automatically update your API documentation in the cloud
+
 ## Configuration
 
 ### Security Definition location

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@
   - [ ] built-in API Console
 
 ## Releases
-**Important:** all the 2.x releases are deployed to npm and can be used via jsdeliver:
+**Important:** all the **2.x** releases are deployed to npm and can be used via jsdeliver:
 - particular release, e.g. `v2.0.0-alpha.15`: https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js
 - `next` release: https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js
 
 Additionally, all the 1.x releases are hosted on our GitHub Pages-based CDN **(deprecated)**:
 - particular release, e.g. `v1.2.0`: https://rebilly.github.io/ReDoc/releases/v1.2.0/redoc.min.js
 - `v1.x.x` release: https://rebilly.github.io/ReDoc/releases/v1.x.x/redoc.min.js
-- `latest` release: https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js - it will point to latest 1.x.x release since 2.x releases are not hosted on this CDN but on unpkg.
+- `latest` release: https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js - it will point to latest `1.x.x` release since `2.x` releases are not hosted on this CDN but on unpkg.
 
 ## Version Guidance
 | ReDoc Release | OpenAPI Specification |
@@ -200,7 +200,7 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 
 ## ReDoc CLI
 
-[ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition(s) into **zero-dependency** HTML file. It can be installed as a development dependency in your project.
+[ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition into **zero-dependency** HTML file. It can be installed as a development dependency in your project.
 
 ## Create-openapi-repo
 [Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files organized in folders **compatible with version 3x only**. You can also use this tool to start a new API definition and validate your OpenAPI definition.
@@ -214,7 +214,7 @@ The [Redocly CE](https://redoc.ly/redoc) is free and open source and is aimed at
 * [Openapi-cli](https://redoc.ly/openapi-cli): lint and bundle your OpenAPI definition(s).
 * [Create-openapi-repo](https://github.com/Redocly/create-openapi-repo): write and start a new OpenAPI definition.
 
-The [Redocly PE](https://redoc.ly/pricing) comes in the starter versions and the paid versions. The [Redocly PE](https://redoc.ly/pricing)products are:
+The [Redocly PE](https://redoc.ly/pricing) comes in the starter versions and the paid versions. The [Redocly PE](https://redoc.ly/pricing) products are:
 * [API Reference Docs](https://redoc.ly/reference-docs): easily create, style, and manage your API documentation with advanced developer friendly features.
 * [Developer Portal (Beta)](https://redoc.ly/developer-portal): where docs-as-code meets docs-as-marketing.
 * [Workflows](https://redoc.ly/workflows): build, maintain, and automatically update your API documentation in the cloud.
@@ -298,7 +298,7 @@ Redocly has a variety of products, this table shows an overview of all Redocly p
 | Redoc | The API reference documentation output from the OpenAPI definition. This edition has limited functionality.  | Community Edition |
 | create-openapi-repo   | CLI tool for splitting a single OpenAPI definition file into multiple files, start a new API definition, validating your OpenAPI definition, and other features. | Community Edition  |
 | openapi-cli  | CLI tool that provides linting against a customizable rules, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool. | Community Edition  |
-| API Reference Docs | The premium version of Redoc – the API reference documentation output from the OpenAPI definition file. This premium version includes Try-it functionality, enhanced search, fast loading, special tags, and other advanced features. | Premium Editon  |
+| API Reference Docs | The premium version of Redoc – the API reference documentation output from the OpenAPI definition file. This premium version includes `Try-it functionality`, `enhanced search`, `fast loading`, `special tags`, and other advanced features. | Premium Editon  |
 | Developer Portal (beta)  | A sample `starter` developer portal, built on top of Gatsby. Intended for more robust documentation such as landing pages, how-to guides, tutorials and so much more. | Premium Editon  |
 | Workflows | An online Redocly app that provides the full authoring and publishing toolset in the cloud, with GitHub, Gitlab, Azure and Bitbucket integration and docs-as-code worflows. | Premium Editon |
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
   - [ ] built-in API Console
 
 ## Releases
-**Important:** all the **2.x** releases are deployed to `npm` and can be used via `jsdeliver`:
+**Important:** all the **2.x** releases are deployed to `npm` and can be used via `jsDelivr`:
 - particular release, e.g. `v2.0.0-alpha.17`: https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js
 - `next` release: https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js
 

--- a/README.md
+++ b/README.md
@@ -200,10 +200,10 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 
 ## ReDoc CLI
 
-[ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition(s). It can be installed as a development dependency in your project to generate documentation for your API specification
+[ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition(s) into **zero-dependency** HTML file .It can be installed as a development dependency in your project.
 
-## create-openapi-repo
-[create-openapi-repo](https://github.com/Redocly/create-openapi-repo) `cli` tool is used for splitting a single OpenAPI definition file into multiple files (compatible with version 3x only). You can also use this `cli` tool to start a new API definition.
+## Create-openapi-repo
+[Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files (compatible with version 3x only). You can also use this tool to start a new API definition.
 
 ## Community Edition(CE) vs Premium Edition(PE)
 
@@ -211,7 +211,8 @@ Redocly offers two different editions: the [Community Edition (CE)](https://redo
 
 The **Redocly CE** is free and open source and is aimed at developers and teams who are looking to create easily deployable API documentation. The **Redocly CE** benefits are:
 * [Redoc](https://redoc.ly/redoc) simple to set up: no server required and fully customizable theme.
-* [Openapi-cli](https://redoc.ly/openapi-cli) validate a multi-file OpenAPI definition
+* [Openapi-cli](https://redoc.ly/openapi-cli) lint and bundle your OpenAPI definition(s)
+* [Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) write and start a new OpenAPI definition.
 
 The **Redocly PE** comes in the starter versions and the paid versions. The **Redocly PE** benefits are:
 * [Reference documentation](https://redoc.ly/reference-docs) easily create, style, and manage your API documentation with advanced developer friendly features

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 
 ## ReDoc CLI
 
-[ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) can be installed as a development dependency in your project to generate documentation for your API specification
+[ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition(s). It can be installed as a development dependency in your project to generate documentation for your API specification
 
 ## create-openapi-repo
 [create-openapi-repo](https://github.com/Redocly/create-openapi-repo) `cli` tool is used for splitting a single OpenAPI definition file into multiple files (compatible with version 3x only). You can also use this `cli` tool to start a new API definition.

--- a/README.md
+++ b/README.md
@@ -209,12 +209,12 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 
 Redocly offers two different editions: the [Community Edition (CE)](https://redoc.ly/redoc) and the [Premium Edition (PE)](https://redoc.ly/pricing). They offer the same easily deployable API documentation, fully supporting OpenAPI v2 and OpenAPI v3., but the difference is the limited features which is only available in the Premium Edition.
 
-The **Redocly CE** is free and open source and is aimed at developers and teams who are looking to create easily deployable API documentation. The **Redocly CE** products are:
+The [Redocly CE](https://redoc.ly/redoc) is free and open source and is aimed at developers and teams who are looking to create easily deployable API documentation. The [Redocly CE](https://redoc.ly/redoc) products are:
 * [Redoc](https://redoc.ly/redoc): simple to set up: no server required and fully customizable theme.
 * [Openapi-cli](https://redoc.ly/openapi-cli): lint and bundle your OpenAPI definition(s)
 * [Create-openapi-repo](https://github.com/Redocly/create-openapi-repo): write and start a new OpenAPI definition.
 
-The **Redocly PE** comes in the starter versions and the paid versions. The **Redocly PE** products are:
+The [Redocly PE](https://redoc.ly/pricing) comes in the starter versions and the paid versions. The [Redocly PE](https://redoc.ly/pricing)products are:
 * [API Reference](https://redoc.ly/reference-docs): easily create, style, and manage your API documentation with advanced developer friendly features
 * [Developer Portal (Beta)](https://redoc.ly/developer-portal): where docs-as-code meets docs-as-marketing
 * [Workflows](https://redoc.ly/workflows): build, maintain, and automatically update your API documentation in the cloud
@@ -298,9 +298,9 @@ Redocly has a variety of products, this table shows an overview of all Redocly p
 | Redoc | The API reference documentation output from the OpenAPI definition. This free version has limited functionality.  | Community Edition |
 | create-openapi-repo   | CLI tool for splitting a single OpenAPI definition file into multiple files (compatible with version 3x only). You can also use this CLI tool to start a new API definition. | Community Edition  |
 | openapi-cli  | CLI tool that provides linting against a customizable ruleset, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool. | Community Edition  |
-| Redocly API Reference   | The premium version of Redoc – the API reference documentation output from the OpenAPI definition file. This premium version includes Try-it functionality, enhanced search, fast loading, special tags, and other features. | Premium Editon  |
-| Developer Portal (beta)  | A sample “starter” developer portal, built on top of Gatsby. Intended for more robust documentation scenarios. | Premium Editon  |
-| Workflows | A online Redocly app that provides the full authoring and publishing toolset in the cloud, with GitHub integration and docs-as-code worflows | Premium Editon  |
+| Redocly API Reference | The premium version of Redoc – the API reference documentation output from the OpenAPI definition file. This premium version includes Try-it functionality, enhanced search, fast loading, special tags, and other features. | Premium Editon  |
+| Developer Portal (beta)  | A sample `starter` developer portal, built on top of Gatsby. Intended for more robust documentation scenarios. | Premium Editon  |
+| Workflows | A online Redocly app that provides the full authoring and publishing toolset in the cloud, with GitHub integration and docs-as-code worflows | Premium Editon |
 
 ## Join Us
 **WE'RE HIRING!** Love APIs and working with distributed teams? Learn more about our [open positions](https://redoc.ly/careers)

--- a/README.md
+++ b/README.md
@@ -284,5 +284,9 @@ Redoc.init('http://petstore.swagger.io/v2/swagger.json', {
 ```
 
 -----------
+
+## Join Us
+WE'RE HIRING! Love APIs and working with distributed systems? Learn more about our [open positions](https://redoc.ly/careers)
+
 ## Development
 see [CONTRIBUTING.md](.github/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Redoc.init('http://petstore.swagger.io/v2/swagger.json', {
 -----------
 
 ## Join Us
-WE'RE HIRING! Love APIs and working with distributed teams? Learn more about our [open positions](https://redoc.ly/careers)
+**WE'RE HIRING!** Love APIs and working with distributed teams? Learn more about our [open positions](https://redoc.ly/careers)
 
 ## Development
 see [CONTRIBUTING.md](.github/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 
 [ReDoc CLI](https://github.com/Redocly/redoc/blob/master/cli/README.md) tool is used to lint and bundle your OpenAPI definition into **zero-dependency** HTML file. It can be installed as a development dependency in your project.
 
-## Create-openapi-repo
-[Create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files organized in folders. You can also use this tool to start a new API definition and validate your OpenAPI definition.
+## Generator for GH repo
+[create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool is used for splitting a single OpenAPI definition file into multiple files organized in folders. You can also use this tool to start a new API definition and validate your OpenAPI definition.
 
 ## Community Edition(CE) vs Premium Edition(PE)
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
-# redoc-cli
+# Redoc-cli
 
-**[ReDoc](https://github.com/Redocly/redoc)'s Command Line Interface**
+Redoc CLI tool provides linting against a customizable ruleset, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool.
 
 ## Installation
 You can use redoc cli by installing `redoc-cli` globally or using [npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # Redoc-cli
 
-Redoc CLI tool provides linting against a customizable ruleset, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool.
+Redoc CLI is an open source tool that provides linting against a customizable ruleset, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool.
 
 ## Installation
 You can use redoc cli by installing `redoc-cli` globally or using [npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # Redoc-cli
 
-Redoc CLI is an open source tool that provides linting against a customizable ruleset, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool.
+Redoc-cli is an open source tool that provides linting against a customizable ruleset, as well as bundling of the OpenAPI files into a single file. You can also preview the output of your docs with the Redocly API References through this tool.
 
 ## Installation
 You can use redoc cli by installing `redoc-cli` globally or using [npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).


### PR DESCRIPTION
1.  comparison of features of the community edition vs. premium
2.  careers available mentions (link to Redoc.ly/careers)
3.  create-openapi-repo tool definition and link
4.  Redoc CLI definition and link
5. A table to show the overview of Redocly Product
6. Update Redoc CLI Readme
7. Edits to the Readme documentation where it was needed