### PR TITLE
Create the first draft of the FAQ document

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,8 +8,10 @@ Hi! We're really excited that you are interested in contributing to ReDoc. Befor
 - [Project Structure](#project-structure)
 
 ## Issue Reporting Guidelines
-- Before filing a new issue, try to make sure your problem doesn’t already exist.
+- Before filing a new issue, try to make sure your problem hasn't already been reported. Check our [FAQ](https://github.com/Redocly/redoc/blob/master/FAQ.md) for a list of common questions and problems.
+- When describing your issue, let us know which version of ReDoc you are using.
 - The best way to get your bug fixed is to provide a reduced test case.
+- We recommend sharing lengthy code and spec examples [in a gist](https://gist.github.com/) instead of pasting them directly into the issue description or comments. This makes the discussions more readable and easier to follow.
 
 ## Pull Request Guidelines
 Before submitting a pull request, please make sure the following is done:

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,150 @@
+# Frequently Asked Questions
+
+This document lists common questions and issues raised by ReDoc users. 
+Before reporting a new issue, we recommend reading through this list. You might find a solution here, thus avoiding duplicate issues.
+
+**Products covered in this FAQ**
+
+[ReDoc Community Edition](https://redoc.ly/redoc)
+
+  - [command-line interface (redoc-cli)](https://github.com/Redocly/redoc/blob/master/cli/README.md)
+  - standalone ReDoc
+  - React component
+
+
+## Jump To:
+
+### 1. [ReDoc Features and Capabilities](#1-redoc-features-and-capabilities-1)
+
+### 2. [Deploying ReDoc](#2-deploying-redoc-1)
+
+### 3. [Working with Spec Files](#3-working-with-spec-files-1)
+
+### 4. [Troubleshooting ReDoc](#4-troubleshooting-redoc-1)
+
+
+----
+
+
+## 1. ReDoc Features and Capabilities
+
+
+### Can ReDoc load a spec file from the local filesystem and build API documentation from it?
+
+In standalone ReDoc, this is not supported due to browser security restrictions. 
+However, you can use the redoc-cli tool to bundle a local spec file into a zero-dependency HTML file.
+In this context, "zero-dependency" means that the bundled HTML file already contains all necessary scripts inside, and does not need to refer to any
+external files to display the content properly.
+
+
+### Can ReDoc autogenerate code examples from my spec file?
+
+ReDoc currently does not support autogenerating code examples. To include code examples in your API documentation,
+you can generate them with a third-party tool, and insert them manually into the spec using the 
+[x-codeSamples vendor extension](https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-codeSamples). 
+
+For more context and advice, refer to: [#15](https://github.com/Redocly/redoc/issues/15), [#309](https://github.com/Redocly/redoc/issues/309)
+
+
+### Can I add a "Try It" feature to my ReDoc-generated API docs?
+
+In ReDoc Community Edition, this feature is not supported. Consider upgrading to our premium API Reference Docs product, 
+which [supports the API Console feature](https://redoc.ly/docs/api-reference-docs/console-overview/).
+
+
+### Are there any ReDoc-only features that other tools do not support?
+
+The following vendor extensions are ReDoc-specific and will be ignored by other tools:
+
+- `x-additionalPropertiesName`
+- `x-extendedDiscriminator`
+
+Refer to [our documentation](https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md) for usage details.
+
+
+### Can I import my API data from Postman into ReDoc?
+
+ReDoc does not integrate with Postman on this level. However, it may be possible to convert Postman Collections and schemas to OpenAPI with third-party tools,
+and then use those OpenAPI spec files with ReDoc.
+
+
+## 2. Deploying ReDoc
+
+
+### Can I generate API docs with ReDoc from multiple spec files?
+
+Yes, there are several ways to do this. On the spec level, you can use internal reference links ($ref) to connect multiple specs, and ReDoc will combine them
+into a single HTML. Be careful with file paths when inserting reference links into the spec, especially if your spec files are in different locations.
+
+Alternatively, you can create a separate HTML file for each spec file, and manually insert links into each HTML to connect them.
+
+For more context and advice, refer to: [#187](https://github.com/Redocly/redoc/issues/187), [#226](https://github.com/Redocly/redoc/issues/226), 
+[#1106](https://github.com/Redocly/redoc/issues/1106)
+
+
+### How can I modify ReDoc options and theme if I'm using redoc-cli to generate HTML?
+
+In ReDoc Community Edition, the same [set of options](https://github.com/Redocly/redoc#redoc-options-object) is supported for all ReDoc variants (redoc-cli,
+standalone ReDoc, React component). 
+
+If you want to modify a long list of options, it's more convenient to save them in a JSON file and pass it to redoc-cli:
+
+`redoc bundle --options=options.json your-spec-file`
+
+
+## 3. Working with Spec Files
+
+### What are some best practices for writing OpenAPI specs?
+
+[Our documentation](https://redoc.ly/docs/resources/openapi-decisions/) offers advice for common challenges with OpenAPI workflows, 
+as well as links to resources where you can learn more about the OpenAPI specification.
+
+### I'm trying to use Markdown in my spec files, but ReDoc is not generating it properly. What's wrong?
+
+ReDoc follows the OpenAPI specification and supports CommonMark formatting in specification `description` fields. You may encounter issues with rendering
+Markdown if you set the ReDoc option `untrustedSpec` to `true`, because it sanitizes all HTML/Markdown to prevent XSS (cross-site scripting).
+
+A notable difference between OpenAPI specification and ReDoc is that ReDoc supports Markdown tables in `description` fields. A table must be formatted with a
+newline before and after it, and must use the pipe symbol (`|`) as the multiline string indicator.
+
+
+## 4. Troubleshooting ReDoc
+
+
+### My ReDoc-generated documentation is showing weird symbols in place of some characters or icons. What's wrong?
+
+This is likely an encoding issue. Make sure `<meta charset="UTF-8" />` is set in the `<head>` section of your ReDoc HTML.
+
+For more context and advice, refer to: [#213](https://github.com/Redocly/redoc/issues/213)
+
+
+### I'm trying to group endpoints using tags in my spec, but ReDoc is not showing them. What's wrong?
+
+ReDoc supports the `x-tagGroups` vendor extension that allows you to organize the way your endpoints are presented in the ReDoc sidebar. 
+
+If you are using this extension, and you forget to add a tag into a group, endpoints with this tag will not be displayed in the sidebar at all.
+To ensure all your endpoints are always displayed in the sidebar, consider writing a linter rule that will enforce tags for all endpoints. 
+You can also create a generic tag group to hold all your endpoints that don't belong anywhere else. 
+
+
+### I'm having trouble using ReDoc in Internet Explorer. Is this browser supported?
+
+Support for the Internet Explorer browser depends on the version. IE9 and prior are not supported by ReDoc.
+IE10 and IE11 are supported by default if ReDoc is used as a standalone package. 
+Refer to [our documentation](https://github.com/Redocly/redoc/blob/master/docs/usage-with-ie11.md) if you're using ReDoc as a React component with IE11. 
+
+
+### How can I optimize ReDoc performance?
+
+If ReDoc-generated documentation seems slow to load, consider reducing the amount of endpoints and code examples in your spec (if possible).
+Setting the `hideLoading` option to `true` can also help in some cases.
+
+
+### Search in ReDoc is not working the way I expect it to. Are there any known limitations of this feature?
+
+There are a few things regarding ReDoc search to keep in mind:
+
+- When using the search feature in ReDoc-generated API documentation, only the menu items are searched - not the entire content. 
+
+- Because ReDoc relies on [Lunr](https://lunrjs.com/guides/language_support.html) for its search functionality, by default it only supports English. 
+If your spec is written in any other language, ReDoc search will not return any results.

--- a/FAQ.md
+++ b/FAQ.md
@@ -14,7 +14,7 @@ Before reporting a new issue, we recommend reading through this list. You might 
 
 ## Jump To:
 
-### 1. [ReDoc Features and Capabilities](#1-redoc-features-and-capabilities-1)
+### 1. [Understanding ReDoc Features](#1-understanding-redoc-features-1)
 
 ### 2. [Deploying ReDoc](#2-deploying-redoc-1)
 
@@ -26,7 +26,7 @@ Before reporting a new issue, we recommend reading through this list. You might 
 ----
 
 
-## 1. ReDoc Features and Capabilities
+## 1. Understanding ReDoc Features
 
 
 ### Can ReDoc load a spec file from the local filesystem and build API documentation from it?

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,150 +1,151 @@
 # Frequently Asked Questions
 
-This document lists common questions and issues raised by ReDoc users. 
+This document lists common questions and issues raised by Redoc users. 
 Before reporting a new issue, we recommend reading through this list. You might find a solution here, thus avoiding duplicate issues.
 
 **Products covered in this FAQ**
 
-[ReDoc Community Edition](https://redoc.ly/redoc)
+[Redoc Community Edition](https://redoc.ly/redoc), which you can use as:
 
-  - [command-line interface (redoc-cli)](https://github.com/Redocly/redoc/blob/master/cli/README.md)
-  - standalone ReDoc
-  - React component
+  - a local or CDN-hosted JS script in your HTML
+  - a React component
+  - [a command-line interface tool (redoc-cli)](https://github.com/Redocly/redoc/blob/master/cli/README.md)
 
 
 ## Jump To:
 
-### 1. [Understanding ReDoc Features](#1-understanding-redoc-features-1)
+### 1. [Understanding Redoc Features](#1-understanding-redoc-features-1)
 
-### 2. [Deploying ReDoc](#2-deploying-redoc-1)
+### 2. [Deploying Redoc](#2-deploying-redoc-1)
 
-### 3. [Working with Spec Files](#3-working-with-spec-files-1)
+### 3. [Working with OpenAPI Definition Files](#3-working-with-openapi-definition-files-1)
 
-### 4. [Troubleshooting ReDoc](#4-troubleshooting-redoc-1)
+### 4. [Troubleshooting Redoc](#4-troubleshooting-redoc-1)
 
 
 ----
 
 
-## 1. Understanding ReDoc Features
+## 1. Understanding Redoc Features
 
 
-### Can ReDoc load a spec file from the local filesystem and build API documentation from it?
+### Can Redoc load an API definition file from the local filesystem and build documentation from it?
 
-In standalone ReDoc, this is not supported due to browser security restrictions. 
-However, you can use the redoc-cli tool to bundle a local spec file into a zero-dependency HTML file.
-In this context, "zero-dependency" means that the bundled HTML file already contains all necessary scripts inside, and does not need to refer to any
-external files to display the content properly.
+When using Redoc as a JS script, this is not supported due to browser security restrictions. 
+However, you can use the redoc-cli tool to bundle a local API definition file into a zero-dependency, static HTML file.
+In this context, "zero-dependency" means that the HTML file already contains all the necessary resources inside, and does not need to refer to any
+external scripts to display the content properly.
 
 
-### Can ReDoc autogenerate code examples from my spec file?
+### Can Redoc autogenerate code examples from my API definition?
 
-ReDoc currently does not support autogenerating code examples. To include code examples in your API documentation,
-you can generate them with a third-party tool, and insert them manually into the spec using the 
+Redoc currently does not support autogenerating code examples. To include code examples in your API documentation,
+you can generate them with a third-party tool, and insert them manually into your API definition using the 
 [x-codeSamples vendor extension](https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-codeSamples). 
 
 For more context and advice, refer to: [#15](https://github.com/Redocly/redoc/issues/15), [#309](https://github.com/Redocly/redoc/issues/309)
 
 
-### Can I add a "Try It" feature to my ReDoc-generated API docs?
+### Can I add a "Try It" feature to my Redoc-generated API docs?
 
-In ReDoc Community Edition, this feature is not supported. Consider upgrading to our premium API Reference Docs product, 
+In Redoc Community Edition, this feature is not supported. Consider upgrading to our premium API Reference Docs product, 
 which [supports the API Console feature](https://redoc.ly/docs/api-reference-docs/console-overview/).
 
 
-### Are there any ReDoc-only features that other tools do not support?
+### Are there any Redoc-only features that other tools do not support?
 
-The following vendor extensions are ReDoc-specific and will be ignored by other tools:
-
-- `x-additionalPropertiesName`
-- `x-extendedDiscriminator`
-
-Refer to [our documentation](https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md) for usage details.
+Redoc supports advanced OpenAPI v3 declarations like nested objects, the discriminator, “one of”, “any of”, “all of”, nullable, and callbacks, which are not properly supported by other API documentation tools. Redoc also supports multiple response and request examples per path.
 
 
-### Can I import my API data from Postman into ReDoc?
+### Can I import my API data from Postman into Redoc?
 
-ReDoc does not integrate with Postman on this level. However, it may be possible to convert Postman Collections and schemas to OpenAPI with third-party tools,
-and then use those OpenAPI spec files with ReDoc.
-
-
-## 2. Deploying ReDoc
+Redoc does not integrate with Postman on this level. However, it may be possible to convert Postman Collections and schemas to OpenAPI definitions with third-party tools, and then use those OpenAPI definition files with Redoc.
 
 
-### Can I generate API docs with ReDoc from multiple spec files?
+## 2. Deploying Redoc
 
-Yes, there are several ways to do this. On the spec level, you can use internal reference links ($ref) to connect multiple specs, and ReDoc will combine them
-into a single HTML. Be careful with file paths when inserting reference links into the spec, especially if your spec files are in different locations.
 
-Alternatively, you can create a separate HTML file for each spec file, and manually insert links into each HTML to connect them.
+### Can I generate docs with Redoc from multiple API definition files?
+
+Yes, there are several ways to do this. On the API definition level, you can use internal reference links ($ref) to bring in content from multiple files. Redoc automatically resolves the references and combines multiple API definition files into a single HTML. Be careful with file paths when inserting reference links into the API definition, especially if your files are in different locations.
+
+Alternatively, you can create a separate HTML file for each API definition file, and manually insert links into each HTML to connect them.
 
 For more context and advice, refer to: [#187](https://github.com/Redocly/redoc/issues/187), [#226](https://github.com/Redocly/redoc/issues/226), 
 [#1106](https://github.com/Redocly/redoc/issues/1106)
 
 
-### How can I modify ReDoc options and theme if I'm using redoc-cli to generate HTML?
+### How can I modify Redoc options and theme if I'm using redoc-cli?
 
-In ReDoc Community Edition, the same [set of options](https://github.com/Redocly/redoc#redoc-options-object) is supported for all ReDoc variants (redoc-cli,
-standalone ReDoc, React component). 
+In Redoc Community Edition, the same [set of options](https://github.com/Redocly/redoc#redoc-options-object) is supported regardless of how you're deploying Redoc (redoc-cli, linked JS script, React component).
+
+When using redoc-cli, you should provide the `--options` argument after the `bundle` or `serve` command, followed by the list of configuration parameters and their values. You can format the list in either of the following ways:
+
+`redoc-cli command --options='{"theme":{"colors":{"primary":{"main":"black"}}}}' your-api-definition.yaml`
+
+`redoc-cli command --options.theme.colors.primary.main=black your-api-definition.yaml`
 
 If you want to modify a long list of options, it's more convenient to save them in a JSON file and pass it to redoc-cli:
 
-`redoc bundle --options=options.json your-spec-file`
+`redoc-cli command --options=options.json your-api-definition.yaml`
 
 
-## 3. Working with Spec Files
+## 3. Working with OpenAPI Definition Files
 
-### What are some best practices for writing OpenAPI specs?
+### What are some best practices for writing API definitions?
 
 [Our documentation](https://redoc.ly/docs/resources/openapi-decisions/) offers advice for common challenges with OpenAPI workflows, 
 as well as links to resources where you can learn more about the OpenAPI specification.
 
-### I'm trying to use Markdown in my spec files, but ReDoc is not generating it properly. What's wrong?
+### I'm trying to use Markdown in my OpenAPI definition files, but Redoc is not generating it properly. What's wrong?
 
-ReDoc follows the OpenAPI specification and supports CommonMark formatting in specification `description` fields. You may encounter issues with rendering
-Markdown if you set the ReDoc option `untrustedSpec` to `true`, because it sanitizes all HTML/Markdown to prevent XSS (cross-site scripting).
+Redoc follows the OpenAPI specification and supports CommonMark formatting in specification `description` fields. You may encounter issues with rendering
+Markdown if you set the Redoc option `untrustedSpec` to `true`, because it sanitizes all HTML/Markdown to prevent XSS (cross-site scripting).
 
-A notable difference between OpenAPI specification and ReDoc is that ReDoc supports Markdown tables in `description` fields. A table must be formatted with a
+A notable difference between the OpenAPI specification and Redoc is that Redoc supports Markdown tables in `description` fields. A table must be formatted with a
 newline before and after it, and must use the pipe symbol (`|`) as the multiline string indicator.
 
 
-## 4. Troubleshooting ReDoc
+## 4. Troubleshooting Redoc
 
 
-### My ReDoc-generated documentation is showing weird symbols in place of some characters or icons. What's wrong?
+### My Redoc-generated documentation is showing weird symbols in place of some characters or icons. What's wrong?
 
-This is likely an encoding issue. Make sure `<meta charset="UTF-8" />` is set in the `<head>` section of your ReDoc HTML.
+This is likely an encoding issue. Make sure `<meta charset="UTF-8" />` is set in the `<head>` section of your Redoc HTML.
 
 For more context and advice, refer to: [#213](https://github.com/Redocly/redoc/issues/213)
 
 
-### I'm trying to group endpoints using tags in my spec, but ReDoc is not showing them. What's wrong?
+### I'm trying to group paths by using tags in my API definition, but Redoc is not showing them. What's wrong?
 
-ReDoc supports the `x-tagGroups` vendor extension that allows you to organize the way your endpoints are presented in the ReDoc sidebar. 
+Redoc supports the `x-tagGroups` vendor extension that allows you to organize the paths in your API definition. This also affects the presentation of 
+your paths in the sidebar of the Redoc-generated API documentation. 
 
-If you are using this extension, and you forget to add a tag into a group, endpoints with this tag will not be displayed in the sidebar at all.
-To ensure all your endpoints are always displayed in the sidebar, consider writing a linter rule that will enforce tags for all endpoints. 
-You can also create a generic tag group to hold all your endpoints that don't belong anywhere else. 
+If you are using this vendor extension, and you forget to add a tag into a group, paths with that tag are not displayed in the sidebar at all.
 
-
-### I'm having trouble using ReDoc in Internet Explorer. Is this browser supported?
-
-Support for the Internet Explorer browser depends on the version. IE9 and prior are not supported by ReDoc.
-IE10 and IE11 are supported by default if ReDoc is used as a standalone package. 
-Refer to [our documentation](https://github.com/Redocly/redoc/blob/master/docs/usage-with-ie11.md) if you're using ReDoc as a React component with IE11. 
+To ensure all your paths are always displayed in the sidebar, consider writing a linter rule that will enforce tags for all paths. 
+You can use our [openapi-cli](https://github.com/Redocly/openapi-cli) tool and write custom rules to validate your API definitions before generating API documentation. You can also create a generic tag group to hold all your paths that don't belong anywhere else. 
 
 
-### How can I optimize ReDoc performance?
+### I'm having trouble using Redoc in Internet Explorer. Is this browser supported?
 
-If ReDoc-generated documentation seems slow to load, consider reducing the amount of endpoints and code examples in your spec (if possible).
+Support for the Internet Explorer browser depends on the version. IE9 and prior are not supported by Redoc.
+
+IE10 and IE11 are supported by default if Redoc is used as a JS script linked directly in the HTML. 
+Refer to [our documentation](https://github.com/Redocly/redoc/blob/master/docs/usage-with-ie11.md) if you're using Redoc as a React component with IE11. 
+
+
+### How can I optimize Redoc performance?
+
+If Redoc-generated documentation seems slow to load, consider reducing the amount of paths, methods, and code examples in your API definition (if possible).
 Setting the `hideLoading` option to `true` can also help in some cases.
 
 
-### Search in ReDoc is not working the way I expect it to. Are there any known limitations of this feature?
+### Search in Redoc is not working the way I expect it to. Are there any known limitations of this feature?
 
-There are a few things regarding ReDoc search to keep in mind:
+There are a few things regarding Redoc search to keep in mind:
 
-- When using the search feature in ReDoc-generated API documentation, only the menu items are searched - not the entire content. 
+- When using the search feature in Redoc-generated API documentation, only the menu items are searched - not the entire content. 
 
-- Because ReDoc relies on [Lunr](https://lunrjs.com/guides/language_support.html) for its search functionality, by default it only supports English. 
-If your spec is written in any other language, ReDoc search will not return any results.
+- Because Redoc relies on [Lunr](https://lunrjs.com/guides/language_support.html) for its search functionality, by default it only supports English. 
+If your API definition is written in any other language, Redoc search does not return any results.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
  
  # About ReDoc
  
-TODO: Two-sentence introduction: what it does, who makes it, who it's for.
+TODO: Three-sentence introduction: what it does, who makes it, who it's for.
  
 [Try the live demo](http://redocly.github.io/redoc/)
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,43 @@
 <div align="center">
   <img alt="ReDoc logo" src="https://raw.githubusercontent.com/Redocly/redoc/master/docs/images/redoc-logo.png" width="400px" />
 
-  **OpenAPI/Swagger-generated API Reference Documentation**
+  <h2>Generate interactive API documentation from OpenAPI definitions</h2>
+  
+ </div>
+ 
+ ![ReDoc demo](https://raw.githubusercontent.com/Redocly/redoc/master/demo/redoc-demo.png)
+ 
+ **This README is for the `2.0` version of ReDoc (React-based). README for the `1.x` version is on the [v1.x](https://github.com/Redocly/redoc/tree/v1.x) branch.**
+ 
+ # About ReDoc
+ 
+ Two-sentence introduction: what it does, who makes it, who it's for.
+ 
+[Try the live demo](http://redocly.github.io/redoc/)
 
+[Get started with ReDoc](link to Quick Start section/document)
+ 
+ ## More from Redoc.ly
+ 
+ [<img alt="Deploy to Github" src="http://i.imgur.com/YZmaqk3.png" height="60px">](https://github.com/Rebilly/generator-openapi-repo#generator-openapi-repo--) [<img alt="ReDoc as a service" src="http://i.imgur.com/edqdCv6.png" height="60px">](https://redoc.ly) [<img alt="Customization services" src="http://i.imgur.com/c4sUF7M.png" height="60px">](https://redoc.ly/#services)
+ 
+ **What's the difference between ReDoc and Redoc.ly?**
+ 
+ Describe the difference, mention other products, insert link to detailed feature comparison.
+ 
+ ## Project Status
+ 
   [![Build Status](https://travis-ci.org/Redocly/redoc.svg?branch=master)](https://travis-ci.org/Redocly/redoc) [![Coverage Status](https://coveralls.io/repos/Redocly/redoc/badge.svg?branch=master&service=github)](https://coveralls.io/github/Redocly/redoc?branch=master) [![dependencies Status](https://david-dm.org/Redocly/redoc/status.svg)](https://david-dm.org/Redocly/redoc) [![devDependencies Status](https://david-dm.org/Redocly/redoc/dev-status.svg)](https://david-dm.org/Redocly/redoc#info=devDependencies) [![npm](http://img.shields.io/npm/v/redoc.svg)](https://www.npmjs.com/package/redoc) [![License](https://img.shields.io/npm/l/redoc.svg)](https://github.com/Redocly/redoc/blob/master/LICENSE)
 
   [![bundle size](http://img.badgesize.io/https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js?compression=gzip&max=300000)](https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js) [![npm](https://img.shields.io/npm/dm/redoc.svg)](https://www.npmjs.com/package/redoc) [![](https://data.jsdelivr.com/v1/package/npm/redoc/badge)](https://www.jsdelivr.com/package/npm/redoc) [![Docker Build Status](https://img.shields.io/docker/build/redocly/redoc.svg)](https://hub.docker.com/r/redocly/redoc/)
 
 
-</div>
-
-**This is README for `2.0` version of ReDoc (React based). README for `1.x` version is on the branch [v1.x](https://github.com/Redocly/redoc/tree/v1.x)**
+# Table of Contents
 
 
-![ReDoc demo](https://raw.githubusercontent.com/Redocly/redoc/master/demo/redoc-demo.png)
+# Feature Guide
 
-## [Live demo](http://redocly.github.io/redoc/)
-
-[<img alt="Deploy to Github" src="http://i.imgur.com/YZmaqk3.png" height="60px">](https://github.com/Rebilly/generator-openapi-repo#generator-openapi-repo--) [<img alt="ReDoc as a service" src="http://i.imgur.com/edqdCv6.png" height="60px">](https://redoc.ly) [<img alt="Customization services" src="http://i.imgur.com/c4sUF7M.png" height="60px">](https://redoc.ly/#services)
+Insert a table that compares ReDoc Community Edition features and premium features.
 
 ## Features
 - Extremely easy deployment
@@ -36,43 +56,26 @@
 - Simple integration with `create-react-app` ([sample](https://github.com/APIs-guru/create-react-app-redoc))
 - Branding/customizations via [`theme` option](#redoc-options-object)
 
-## Roadmap
-  - [x] ~~[OpenAPI v3.0 support](https://github.com/Redocly/redoc/issues/312)~~
-  - [x] ~~performance optimizations~~
-  - [x] ~~better navigation (menu improvements + search)~~
-  - [x] ~~React rewrite~~
-  - [x] ~~docs pre-rendering (performance and SEO)~~
-  - [ ] ability to simple branding/styling
-  - [ ] built-in API Console
 
-## Releases
-**Important:** all the 2.x releases are deployed to npm and can be used via jsdeliver:
-- particular release, e.g. `v2.0.0-alpha.15`: https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js
-- `next` release: https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js
+# Quick Start Guide
 
-Additionally, all the 1.x releases are hosted on our GitHub Pages-based CDN **(deprecated)**:
-- particular release, e.g. `v1.2.0`: https://rebilly.github.io/ReDoc/releases/v1.2.0/redoc.min.js
-- `v1.x.x` release: https://rebilly.github.io/ReDoc/releases/v1.x.x/redoc.min.js
-- `latest` release: https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js - it will point to latest 1.x.x release since 2.x releases are not hosted on this CDN but on unpkg.
+- Provide steps for the fastest way to build something
+- Clarify that OpenAPI specs must be edited in another tool - redoc only builds them!
 
-## Version Guidance
-| ReDoc Release | OpenAPI Specification |
-|:--------------|:----------------------|
-| 2.0.0-alpha.x | 3.0, 2.0              |
-| 1.19.x        | 2.0                   |
-| 1.18.x        | 2.0                   |
-| 1.17.x        | 2.0                   |
 
-## Some Real-life usages
-- [Rebilly](https://rebilly-api.redoc.ly/)
-- [Docker Engine](https://docs.docker.com/engine/api/v1.25/)
-- [Zuora](https://www.zuora.com/developer/api-reference/)
-- [Discourse](http://docs.discourse.org)
-- [Commbox](https://www.commbox.io/api/)
-- [APIs.guru](https://apis.guru/api-doc/)
-- [FastAPI](https://github.com/tiangolo/fastapi)
+## Support
 
-## Deployment
+Links to
+
+- **FAQ**
+- **Documentation**
+- **How to report an issue**
+
+
+# Installation and Usage
+
+- List all supported ways to install and deploy
+- For each, include **Dependencies and Prerequisites**
 
 ### TL;DR
 
@@ -202,6 +205,8 @@ Also you may rewrite some predefined environment variables defined in [Dockerfil
 
 [See here](https://github.com/Redocly/redoc/blob/master/cli/README.md)
 
+
+
 ## Configuration
 
 ### Security Definition location
@@ -270,6 +275,61 @@ Redoc.init('http://petstore.swagger.io/v2/swagger.json', {
 }, document.getElementById('redoc-container'))
 ```
 
------------
-## Development
+
+# Who is using ReDoc?
+
+- [Rebilly](https://rebilly-api.redoc.ly/)
+- [Docker Engine](https://docs.docker.com/engine/api/v1.25/)
+- [Zuora](https://www.zuora.com/developer/api-reference/)
+- [Discourse](http://docs.discourse.org)
+- [Commbox](https://www.commbox.io/api/)
+- [APIs.guru](https://apis.guru/api-doc/)
+- [FastAPI](https://github.com/tiangolo/fastapi)
+
+
+# Project Development
+
+
+## Roadmap
+
+  - [x] ~~[OpenAPI v3.0 support](https://github.com/Redocly/redoc/issues/312)~~
+  - [x] ~~performance optimizations~~
+  - [x] ~~better navigation (menu improvements + search)~~
+  - [x] ~~React rewrite~~
+  - [x] ~~docs pre-rendering (performance and SEO)~~
+  - [ ] ability to simple branding/styling
+  - [ ] built-in API Console
+
+
+## Contributing
+
 see [CONTRIBUTING.md](.github/CONTRIBUTING.md)
+
+mention career options
+
+
+## Releases
+
+**Important:** all the 2.x releases are deployed to npm and can be used via jsdeliver:
+- particular release, e.g. `v2.0.0-alpha.15`: https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js
+- `next` release: https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js
+
+Additionally, all the 1.x releases are hosted on our GitHub Pages-based CDN **(deprecated)**:
+- particular release, e.g. `v1.2.0`: https://rebilly.github.io/ReDoc/releases/v1.2.0/redoc.min.js
+- `v1.x.x` release: https://rebilly.github.io/ReDoc/releases/v1.x.x/redoc.min.js
+- `latest` release: https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js - it will point to latest 1.x.x release since 2.x releases are not hosted on this CDN but on unpkg.
+
+## OpenAPI Version Support
+
+| ReDoc Release | OpenAPI Specification |
+|:--------------|:----------------------|
+| 2.0.0-alpha.x | 3.0, 2.0              |
+| 1.19.x        | 2.0                   |
+| 1.18.x        | 2.0                   |
+| 1.17.x        | 2.0                   |
+
+
+
+## License
+
+Add license information.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
  
  # About ReDoc
  
- Two-sentence introduction: what it does, who makes it, who it's for.
+TODO: Two-sentence introduction: what it does, who makes it, who it's for.
  
 [Try the live demo](http://redocly.github.io/redoc/)
 
@@ -21,49 +21,67 @@
  
  [<img alt="Deploy to Github" src="http://i.imgur.com/YZmaqk3.png" height="60px">](https://github.com/Rebilly/generator-openapi-repo#generator-openapi-repo--) [<img alt="ReDoc as a service" src="http://i.imgur.com/edqdCv6.png" height="60px">](https://redoc.ly) [<img alt="Customization services" src="http://i.imgur.com/c4sUF7M.png" height="60px">](https://redoc.ly/#services)
  
- **What's the difference between ReDoc and Redoc.ly?**
+ **What's the difference between ReDoc and other Redoc.ly products?**
  
- Describe the difference, mention other products, insert link to detailed feature comparison.
+TODO: Describe the difference, insert link to detailed feature comparison.
  
  ## Project Status
  
-  [![Build Status](https://travis-ci.org/Redocly/redoc.svg?branch=master)](https://travis-ci.org/Redocly/redoc) [![Coverage Status](https://coveralls.io/repos/Redocly/redoc/badge.svg?branch=master&service=github)](https://coveralls.io/github/Redocly/redoc?branch=master) [![dependencies Status](https://david-dm.org/Redocly/redoc/status.svg)](https://david-dm.org/Redocly/redoc) [![devDependencies Status](https://david-dm.org/Redocly/redoc/dev-status.svg)](https://david-dm.org/Redocly/redoc#info=devDependencies) [![npm](http://img.shields.io/npm/v/redoc.svg)](https://www.npmjs.com/package/redoc) [![License](https://img.shields.io/npm/l/redoc.svg)](https://github.com/Redocly/redoc/blob/master/LICENSE)
+  [![Build Status](https://travis-ci.org/Redocly/redoc.svg?branch=master)](https://travis-ci.org/Redocly/redoc) [![Coverage Status](https://coveralls.io/repos/Redocly/redoc/badge.svg?branch=master&service=github)](https://coveralls.io/github/Redocly/redoc?branch=master) [![npm](http://img.shields.io/npm/v/redoc.svg)](https://www.npmjs.com/package/redoc) 
 
   [![bundle size](http://img.badgesize.io/https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js?compression=gzip&max=300000)](https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js) [![npm](https://img.shields.io/npm/dm/redoc.svg)](https://www.npmjs.com/package/redoc) [![](https://data.jsdelivr.com/v1/package/npm/redoc/badge)](https://www.jsdelivr.com/package/npm/redoc) [![Docker Build Status](https://img.shields.io/docker/build/redocly/redoc.svg)](https://hub.docker.com/r/redocly/redoc/)
+  
+  **Project License** 
+  
+[![License](https://img.shields.io/npm/l/redoc.svg)](https://github.com/Redocly/redoc/blob/master/LICENSE)
+  
+TODO: Link to contributing guidelines
 
 
 # Table of Contents
 
+TODO: add links
+
+- Feature Guide
+- Quick Start Guide
+  - Support
+- Installation and Usage
+  - Standalone
+  - React component
+  - redoc-cli
+  - Docker
+- Configuration
+  - Advanced Options
+- Who is using ReDoc?
+- Project Development
+  - Roadmap
+  - Contributing
+  - Releases
+  - OpenAPI Version Support
+
 
 # Feature Guide
 
+TODO:
+
 Insert a table that compares ReDoc Community Edition features and premium features.
 
-## Features
-- Extremely easy deployment
-- [redoc-cli](https://github.com/Redocly/redoc/blob/master/cli/README.md) with ability to bundle your docs into **zero-dependency** HTML file
-- Server Side Rendering ready
-- The widest OpenAPI v2.0 features support (yes, it supports even `discriminator`) <br>
-![](docs/images/discriminator-demo.gif)
-- OpenAPI 3.0 support
-- Neat **interactive** documentation for nested objects <br>
-![](docs/images/nested-demo.gif)
-- Code samples support (via vendor extension) <br>
-![](docs/images/code-samples-demo.gif)
-- Responsive three-panel design with menu/scrolling synchronization
-- Integrate API Introduction into side menu - ReDoc takes advantage of markdown headings from OpenAPI description field. It pulls them into side menu and also supports deep linking.
-- High-level grouping in side-menu via [`x-tagGroups`](docs/redoc-vendor-extensions.md#x-tagGroups) vendor extension
-- Simple integration with `create-react-app` ([sample](https://github.com/APIs-guru/create-react-app-redoc))
-- Branding/customizations via [`theme` option](#redoc-options-object)
+Clean up the old list of features with animated GIFs.
+
+Mention how ReDoc can integrate into a workflow with other tools like create-openapi-repo.
 
 
 # Quick Start Guide
+
+TODO:
 
 - Provide steps for the fastest way to build something
 - Clarify that OpenAPI specs must be edited in another tool - redoc only builds them!
 
 
 ## Support
+
+TODO:
 
 Links to
 
@@ -74,145 +92,20 @@ Links to
 
 # Installation and Usage
 
+TODO:
+
 - List all supported ways to install and deploy
 - For each, include **Dependencies and Prerequisites**
 
-### TL;DR
 
-```html
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>ReDoc</title>
-    <!-- needed for adaptive design -->
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+# Configuration
 
-    <!--
-    ReDoc doesn't change outer page styles
-    -->
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-      }
-    </style>
-  </head>
-  <body>
-    <redoc spec-url='http://petstore.swagger.io/v2/swagger.json'></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
-  </body>
-</html>
-```
-That's all folks!
+TODO: Clean up and reorganize this section
 
-**IMPORTANT NOTE:** if you work with untrusted user spec, use `untrusted-spec` [option](#redoc-options-object) to prevent XSS security risks.
-
-### 1. Install ReDoc (skip this step for CDN)
-Install using [npm](https://docs.npmjs.com/getting-started/what-is-npm):
-
-    npm i redoc
-
-or using [yarn](https://yarnpkg.com):
-
-    yarn add redoc
-
-### 2. Reference redoc script in HTML
-For **CDN**:
-```html
-<script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"> </script>
-```
-
-For npm:
-```html
-<script src="node_modules/redoc/bundles/redoc.standalone.js"> </script>
-```
-
-### 3. Add `<redoc>` element to your page
-```html
-<redoc spec-url="url/to/your/spec"></redoc>
-```
-
-### 4. Enjoy :smile:
-
-
-## Usage as a React component
-
-Install peer dependencies required by ReDoc if you don't have them installed already:
-
-    npm i react react-dom mobx@^4.2.0 styled-components core-js
-
-Import `RedocStandalone` component from 'redoc' module:
-
-```js
-import { RedocStandalone } from 'redoc';
-```
-
-and use it somewhere in your component:
-
-```js
-<RedocStandalone specUrl="url/to/your/spec"/>
-```
-
-or
-
-```js
-<RedocStandalone spec={/* spec as an object */}/>
-```
-
-Also you can pass options:
-
-```js
-<RedocStandalone
-  specUrl="http://rebilly.github.io/RebillyAPI/openapi.json"
-  options={{
-    nativeScrollbars: true,
-    theme: { colors: { primary: { main: '#dd5522' } } },
-  }}
-/>
-```
-
-Here are detailed [options docs](#redoc-options-object).
-
-You can also specify `onLoaded` callback which will be called each time Redoc has been fully rendered or when error occurs (with an error as the first argument). *NOTE*: It may be called multiply times if you change component properties
-
-```js
-<RedocStandalone
-  specUrl="http://rebilly.github.io/RebillyAPI/openapi.json"
-  onLoaded={error => {
-    if (!error) {
-      console.log('Yay!');
-    }
-  }}
-/>
-```
-
-[**IE11 Support Notes**](docs/usage-with-ie11.md)
-
-## The Docker way
-
-ReDoc is available as pre-built Docker image in official [Docker Hub repository](https://hub.docker.com/r/redocly/redoc/). You may simply pull & run it:
-
-    docker pull redocly/redoc
-    docker run -p 8080:80 redocly/redoc
-
-Also you may rewrite some predefined environment variables defined in [Dockerfile](./config/docker/Dockerfile). By default ReDoc starts with demo Petstore spec located at `http://petstore.swagger.io/v2/swagger.json`, but you may change this URL using environment variable `SPEC_URL`:
-
-    docker run -p 8080:80 -e SPEC_URL=https://api.example.com/openapi.json redocly/redoc
-
-## ReDoc CLI
-
-[See here](https://github.com/Redocly/redoc/blob/master/cli/README.md)
-
-
-
-## Configuration
-
-### Security Definition location
+## Security Definition location
 You can inject Security Definitions widget into any place of your specification `description`. Check out details [here](docs/security-definitions-injection.md).
 
-### Swagger vendor extensions
+## Swagger vendor extensions
 ReDoc makes use of the following [vendor extensions](https://swagger.io/specification/#specificationExtensions):
 * [`x-logo`](docs/redoc-vendor-extensions.md#x-logo) - is used to specify API logo
 * [`x-traitTag`](docs/redoc-vendor-extensions.md#x-traitTag) - useful for handling out common things like Pagination, Rate-Limits, etc
@@ -225,7 +118,7 @@ ReDoc makes use of the following [vendor extensions](https://swagger.io/specific
 * [`x-ignoredHeaderParameters`](docs/redoc-vendor-extensions.md#x-ignoredHeaderParameters) - ability to specify header parameter names to ignore
 * [`x-additionalPropertiesName`](docs/redoc-vendor-extensions.md#x-additionalPropertiesName) - ability to supply a descriptive name for the additional property keys
 
-### `<redoc>` options object
+## `<redoc>` options object
 You can use all of the following options with standalone version on <redoc> tag by kebab-casing them, e.g. `scrollYOffset` becomes `scroll-y-offset` and `expandResponses` becomes `expand-responses`.
 
 * `disableSearch` - disable search indexing and search box.
@@ -292,6 +185,8 @@ Redoc.init('http://petstore.swagger.io/v2/swagger.json', {
 
 ## Roadmap
 
+TODO: update this
+
   - [x] ~~[OpenAPI v3.0 support](https://github.com/Redocly/redoc/issues/312)~~
   - [x] ~~performance optimizations~~
   - [x] ~~better navigation (menu improvements + search)~~
@@ -303,7 +198,9 @@ Redoc.init('http://petstore.swagger.io/v2/swagger.json', {
 
 ## Contributing
 
-see [CONTRIBUTING.md](.github/CONTRIBUTING.md)
+TODO:
+
+[CONTRIBUTING.md](.github/CONTRIBUTING.md)
 
 mention career options
 
@@ -329,7 +226,3 @@ Additionally, all the 1.x releases are hosted on our GitHub Pages-based CDN **(d
 | 1.17.x        | 2.0                   |
 
 
-
-## License
-
-Add license information.


### PR DESCRIPTION
This PR includes the following changes:

- update Issue Reporting Guidelines to include the link to the new FAQ document and guidance for sharing long code excerpts
- add the FAQ document based on the analysis of ReDoc GitHub issues