### PR TITLE
fix: scale sideMenu labels according to computed font size

### DIFF
--- a/src/components/SideMenu/styled.elements.ts
+++ b/src/components/SideMenu/styled.elements.ts
@@ -7,7 +7,7 @@ import styled, { css, ResolvedThemeInterface } from '../../styled-components';
 export const OperationBadge = styled.span.attrs((props: { type: string }) => ({
   className: `operation-type ${props.type}`,
 }))<{ type: string }>`
-  width: 32px;
+  width: 9ex;
   display: inline-block;
   height: ${props => props.theme.typography.code.fontSize};
   line-height: ${props => props.theme.typography.code.fontSize};

--- a/src/components/SideMenu/styled.elements.ts
+++ b/src/components/SideMenu/styled.elements.ts
@@ -16,7 +16,7 @@ export const OperationBadge = styled.span.attrs((props: { type: string }) => ({
   background-repeat: no-repeat;
   background-position: 6px 4px;
   font-size: 7px;
-  font-family: Verdana; // web-safe
+  font-family: Verdana, sans-serif; // web-safe
   color: white;
   text-transform: uppercase;
   text-align: center;


### PR DESCRIPTION
Closes https://github.com/Redocly/redoc/issues/1180.

See https://github.com/Redocly/redoc/issues/1180#issuecomment-676797731 for the `width` change.

See https://github.com/Redocly/redoc/issues/1180#issuecomment-634545588 for the `font-family` change.

---

Setting units in `px` and `(r)em` uses the CSS-defined `font-size` units (in this case `7px`) and not the computed `font-size`, which means the label size does not scale with the increased minimum font sizes users can set in their browser's settings. Minimum font size is a setting in pretty much every browser on Windows, Linux and MacOS and is likely set to `None` by default.

If a user sets the minimum font size above `7px` (for example `10px`) then the label width (a static `32px`) becomes too short for the text width.

The `ex` unit is supported by Chrome 1+, Edge 12+, Firefox 1+, IE 4+ and Safari 1+. 

|Description|`32px`|`9ex`
|-----------|------|-----
|`7px` font size and no minimum font size (`7px` computed) | ![image](https://user-images.githubusercontent.com/3440094/90698700-50a2fb00-e279-11ea-895f-2d131883f8c0.png)|![image](https://user-images.githubusercontent.com/3440094/90698025-aa0a2a80-e277-11ea-80bc-563826622e97.png)
|`7px` font size and a minimum font size of `10px` (`10px` computed) | ![image](https://user-images.githubusercontent.com/3440094/90698683-441ea280-e279-11ea-927e-063896f0a7d1.png)| ![image](https://user-images.githubusercontent.com/3440094/90698043-b2626580-e277-11ea-8013-fc2a895ba8d0.png)
|`7px` font size and a mimimum font size of `10px` (4K display, `7px` computed) | ![image](https://user-images.githubusercontent.com/3440094/90698740-687a7f00-e279-11ea-933a-94e08549b160.png) | ![image](https://user-images.githubusercontent.com/3440094/90698213-1be27400-e278-11ea-9b4f-1c77cafa080e.png)