### PR TITLE
feat: add optional BASE_PATH to Docker config

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -25,6 +25,7 @@ FROM nginx:alpine
 
 ENV PAGE_TITLE="ReDoc"
 ENV PAGE_FAVICON="favicon.png"
+ENV BASE_PATH=
 ENV SPEC_URL="http://petstore.swagger.io/v2/swagger.json"
 ENV PORT=80
 ENV REDOC_OPTIONS=

--- a/config/docker/README.md
+++ b/config/docker/README.md
@@ -23,9 +23,10 @@ Serve local file and watch for updates:
 
 - `PAGE_TITLE` (default `"ReDoc"`) - page title
 - `PAGE_FAVICON` (default `"favicon.png"`) - URL to page favicon
+- `BASE_PATH` (optional) - prepend favicon & standalone bundle with this path
 - `SPEC_URL` (default `"http://petstore.swagger.io/v2/swagger.json"`) - URL to spec
 - `PORT` (default `80`) - nginx port
-- `REDOC_OPTIONS` - [`<redoc>` tag attributes](https://github.com/Redocly/redoc#redoc-tag-attributes)
+- `REDOC_OPTIONS` (optional) - [`<redoc>` tag attributes](https://github.com/Redocly/redoc#redoc-tag-attributes)
 
 ## Build
 

--- a/config/docker/docker-run.sh
+++ b/config/docker/docker-run.sh
@@ -4,6 +4,7 @@ set -e
 
 sed -i -e "s|%PAGE_TITLE%|$PAGE_TITLE|g" /usr/share/nginx/html/index.html
 sed -i -e "s|%PAGE_FAVICON%|$PAGE_FAVICON|g" /usr/share/nginx/html/index.html
+sed -i -e "s|%BASE_PATH%|$BASE_PATH|g" /usr/share/nginx/html/index.html
 sed -i -e "s|%SPEC_URL%|$SPEC_URL|g" /usr/share/nginx/html/index.html
 sed -i -e "s|%REDOC_OPTIONS%|${REDOC_OPTIONS}|g" /usr/share/nginx/html/index.html
 sed -i -e "s|\(listen\s*\) [0-9]*|\1 ${PORT}|g" /etc/nginx/nginx.conf

--- a/config/docker/index.tpl.html
+++ b/config/docker/index.tpl.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>%PAGE_TITLE%</title>
-  <link rel="icon" href="%PAGE_FAVICON%">
+  <link rel="icon" href="%BASE_PATH%%PAGE_FAVICON%">
   <style>
     body {
       margin: 0;
@@ -20,7 +20,7 @@
 
 <body>
   <redoc spec-url="%SPEC_URL%" %REDOC_OPTIONS%></redoc>
-  <script src="redoc.standalone.js"></script>
+  <script src="%BASE_PATH%redoc.standalone.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
While working with redoc I came accross the lack of a "base path" option in the provided Docker image.

My use case is that I have redoc running behind a reverse proxy routing via path matching. E.g. the reverse proxy receives a request to `<host>/docs`, strips the request URL of `/docs` and forwards it to redoc. The way index.tpl.html is constructed, it tries to load favicon.png from `<host>/favicon.png`. The workaround is to send requests to `<host>/docs/` instead, where it'll be correctly loaded from `<host>/docs/favicon.png`, but this feels dirty.

Setting `BASE_PATH` to `/docs/` will prepend favicon.png, making it load from `<host>/docs/favicon.png` no matter the original request.

A possible alternative to this could be allowing users to specify BUNDLE_URL or similar, which defaults to `redoc.standalone.js`. That way, users could set BUNDLE_URL to `/docs/redoc.standalone.js` and PAGE_FAVICON to `/docs/favicon.png`. Another possible alternative could be to modify the nginx config.

I'd be happy to make adjustments.