### PR TITLE
docs: unqualify mobx version for react usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ For npm:
 
 Install peer dependencies required by ReDoc if you don't have them installed already:
 
-    npm i react react-dom mobx@^4.2.0 styled-components core-js
+    npm i react react-dom mobx styled-components core-js
 
 Import `RedocStandalone` component from 'redoc' module:
 


### PR DESCRIPTION
Per https://github.com/Redocly/redoc/issues/1189#issuecomment-606857342 the latest version works now, and the currently-specified version doesn't.