### PR TITLE
feat: add support for x-description to override description of resolved

### DIFF
--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -164,6 +164,9 @@ export class OpenAPIParser {
         this.exitRef(resolved);
         return res;
       }
+      if (obj['x-description']) {
+        return Object.assign({}, resolved, { description: obj['x-description'] });
+      }
       return resolved;
     }
     return obj;
@@ -229,9 +232,9 @@ export class OpenAPIParser {
         };
       })
       .filter(child => child !== undefined) as Array<{
-      $ref: string | undefined;
-      schema: MergedOpenAPISchema;
-    }>;
+        $ref: string | undefined;
+        schema: MergedOpenAPISchema;
+      }>;
 
     for (const { $ref: subSchemaRef, schema: subSchema } of allOfSchemas) {
       if (


### PR DESCRIPTION
To solve issues like #915 this could be a simple solution.
It overrides the resolved $ref's description with what is set in x-description.
```yml
preview_url:
    x-description: Endpoint at which to preview data
    $ref: #/components/schemas/FooOperationURL
```