### PR TITLE
Fix #1387: Update the styled-components peerDependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "mobx": "^4.2.0 || ^5.0.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "styled-components": "^4.1.1"
+    "styled-components": "^5.1.1"
   },
   "dependencies": {
     "@redocly/react-dropdown-aria": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "mobx": "^4.2.0 || ^5.0.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "styled-components": "^5.1.1"
+    "styled-components": "^4.1.1 || ^5.1.1"
   },
   "dependencies": {
     "@redocly/react-dropdown-aria": "^2.0.11",


### PR DESCRIPTION
In package.json we adjusted the styled-component peerDependecy from 4.11 to 5.1.1 to match the version listed in devDependency.