### PR TITLE
 feat: Dockerfile compatible with OpenShift (#1407)

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -36,6 +36,18 @@ COPY demo/favicon.png /usr/share/nginx/html/
 COPY config/docker/nginx.conf /etc/nginx/
 COPY config/docker/docker-run.sh /usr/local/bin
 
+# Provide rights to the root group to write to nginx repositories (needed to run in OpenShift)
+RUN chgrp -R 0 /etc/nginx && \
+    chgrp -R 0 /usr/share/nginx/html && \
+    chgrp -R 0 /var/cache/nginx && \
+    chgrp -R 0 /var/log/nginx && \
+    chgrp -R 0 /var/run && \
+    chmod -R g+rwX /etc/nginx && \
+    chmod -R g+rwX /usr/share/nginx/html && \
+    chmod -R g+rwX /var/cache/nginx && \
+    chmod -R g+rwX /var/log/nginx && \
+    chmod -R g+rwX /var/run
+
 EXPOSE 80
 
 CMD ["sh", "/usr/local/bin/docker-run.sh"]

--- a/config/docker/README.md
+++ b/config/docker/README.md
@@ -2,6 +2,8 @@
 
 ## Usage
 
+### Docker
+
 Serve remote spec by URL:
 
     docker run -it --rm -p 80:80 \
@@ -12,12 +14,32 @@ Serve local file:
     docker run -it --rm -p 80:80 \
       -v $(pwd)/demo/swagger.yaml:/usr/share/nginx/html/swagger.yaml \
       -e SPEC_URL=swagger.yaml redocly/redoc
-      
+
 Serve local file and watch for updates:
 
     docker run -it --rm -p 80:80 \
       -v $(pwd)/demo/:/usr/share/nginx/html/swagger/ \
       -e SPEC_URL=swagger/swagger.yaml redocly/redoc
+
+### OpenShift
+
+To quote [OpenShift Container Platform-Specific Guidelines](https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines):
+
+> Support Arbitrary User IDs
+>
+> By default, OpenShift Container Platform runs containers using an arbitrarily assigned user ID. This provides additional security against processes escaping the container due to a container engine vulnerability and thereby achieving escalated permissions on the host node.
+>
+> For an image to support running as an arbitrary user, directories and files that may be written to by processes in the image should be owned by the root group and be read/writable by that group. Files to be executed should also have group execute permissions.
+
+To comply with those requirements the `Dockerfile` contains instructions to adapt the rights for the folders:
+
+- `/etc/nginx` because the `docker-run.sh` script modifies it at startup time
+- `/usr/share/nginx/html` because the `docker-run.sh` script modifies it at startup time
+- `/var/cache/nginx` because the Nginx process writes to it
+- `/var/log/nginx` because the Nginx process writes to it
+- `/var/run` because the Nginx process writes to it
+
+Another issue with OpenShift is that the default exposed port `80` cannot be used as it is restricted. So one needs to use another port like `8080` (using the `PORT` configuration as described below), and then to configure the `container spec` accordingly.
 
 ## Runtime configuration options
 


### PR DESCRIPTION
In order to be able to run the Docker container in OpenShift a few tweaks must be done.  
I did them in the `Dockerfile` and added explanations to the associated `Readme.md`.

I think the changes done may not bring regressions, and I thought that it may may have been overkill to introduce a new Docker image for this. Let me know if you prefer otherwise.  
I didn't change the user though as the container seems to work fine even when running as `root`, and I didn't want to introduce potential regressions to non-OpenShift users.
