### PR TITLE
feat: Adding options to redoc-cli to serve static files from a folder

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -18,6 +18,6 @@ Some examples:
 - Serve with `nativeScrollbars` option set to true: <br> `$ redoc-cli serve [spec] --options.nativeScrollbars`
 - Bundle using custom template (check [default template](https://github.com/Redocly/redoc/blob/master/cli/template.hbs) for reference): <br> `$ redoc-cli bundle [spec] -t custom.hbs`
 - Bundle using custom template and add custom `templateOptions`: <br> `$ redoc-cli bundle [spec] -t custom.hbs --templateOptions.metaDescription "Page meta description"`
-- Allow a specific folder for be statically served: `$ redoc-cli serve [spec] --static resources`
+- Allow a specific folder to be statically served: `$ redoc-cli serve [spec] --static resources`
 
 For more details run `redoc-cli --help`.

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,5 +18,6 @@ Some examples:
 - Serve with `nativeScrollbars` option set to true: <br> `$ redoc-cli serve [spec] --options.nativeScrollbars`
 - Bundle using custom template (check [default template](https://github.com/Redocly/redoc/blob/master/cli/template.hbs) for reference): <br> `$ redoc-cli bundle [spec] -t custom.hbs`
 - Bundle using custom template and add custom `templateOptions`: <br> `$ redoc-cli bundle [spec] -t custom.hbs --templateOptions.metaDescription "Page meta description"`
+- Allow `./resources` folder for be statically served: `$ redoc-cli serve [spec] --static resources`
 
 For more details run `redoc-cli --help`.

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,6 +18,6 @@ Some examples:
 - Serve with `nativeScrollbars` option set to true: <br> `$ redoc-cli serve [spec] --options.nativeScrollbars`
 - Bundle using custom template (check [default template](https://github.com/Redocly/redoc/blob/master/cli/template.hbs) for reference): <br> `$ redoc-cli bundle [spec] -t custom.hbs`
 - Bundle using custom template and add custom `templateOptions`: <br> `$ redoc-cli bundle [spec] -t custom.hbs --templateOptions.metaDescription "Page meta description"`
-- Allow `./resources` folder for be statically served: `$ redoc-cli serve [spec] --static resources`
+- Allow a specific folder for be statically served: `$ redoc-cli serve [spec] --static resources`
 
 For more details run `redoc-cli --help`.

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -6,7 +6,7 @@ import { ServerStyleSheet } from 'styled-components';
 
 import { compile } from 'handlebars';
 import { createServer, IncomingMessage, ServerResponse } from 'http';
-import { dirname, join, resolve } from 'path';
+import { dirname, join, resolve, normalize, relative } from 'path';
 import { lookup } from 'mime-types';
 
 import * as zlib from 'zlib';
@@ -202,8 +202,9 @@ async function serve(port: number, pathToSpec: string, options: Options = {}) {
         'Content-Type': 'application/json',
       });
     } else {
-      if (options.static && options.static !== '' && request.url?.startsWith('/' + options.static)) {
-        const filePath = join(dirname(pathToSpec), request.url);
+      const filePath = normalize(join(dirname(pathToSpec), request.url || ''));
+      const relativePath = relative(dirname(pathToSpec), filePath);
+      if (options.static && options.static !== '' && relativePath.startsWith(options.static)) {
         const file = createReadStream(filePath);
         file.on('open', function () {
           response.setHeader('Content-Type', lookup(filePath) || 'text/plain');

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -204,7 +204,7 @@ async function serve(port: number, pathToSpec: string, options: Options = {}) {
     } else {
       const filePath = normalize(join(dirname(pathToSpec), request.url || ''));
       const relativePath = relative(dirname(pathToSpec), filePath);
-      if (options.static && options.static !== '' && relativePath.startsWith(options.static)) {
+      if (options.static && options.static !== '' && relativePath.startsWith(options.static + '/')) {
         const file = createReadStream(filePath);
         file.on('open', function () {
           response.setHeader('Content-Type', lookup(filePath) || 'text/plain');

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -204,20 +204,14 @@ async function serve(port: number, pathToSpec: string, options: Options = {}) {
     } else {
       if (options.static && options.static !== '' && request.url?.startsWith('/' + options.static)) {
         const filePath = join(dirname(pathToSpec), request.url);
-        const fileExists = existsSync(filePath);
-        if (fileExists) {
-
-          respondWithGzip(
-            createReadStream(filePath, 'utf8'),
-            request,
-            response,
-            {
-              'Content-Type': lookup(filePath),
-            },
-          );
-        } else {
+        const file = createReadStream(filePath);
+        file.on('open', function () {
+          response.setHeader('Content-Type', lookup(filePath) || 'text/plain');
+          file.pipe(response);
+        });
+        file.on('error', function () {
           fileNotFound();
-        }
+        });
       } else {
         fileNotFound();
       }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -76,6 +76,7 @@ YargsParser.command(
 
     yargs.option('static', {
       type: 'string',
+      describe: 'Add folder to be served statically'
     });
 
     yargs.demandOption('spec');
@@ -95,7 +96,7 @@ YargsParser.command(
     console.log(config);
 
     try {
-      await serve(argv.port as number, argv.spec as string, argv.static as string, config);
+      await serve(argv.port as number, argv.spec as string, config);
     } catch (e) {
       handleError(e);
     }
@@ -169,7 +170,7 @@ YargsParser.command(
     describe: 'ReDoc options, use dot notation, e.g. options.nativeScrollbars',
   }).argv;
 
-async function serve(port: number, pathToSpec: string, staticFolder: string,  options: Options = {}) {
+async function serve(port: number, pathToSpec: string, options: Options = {}) {
   let spec = await loadAndBundleSpec(pathToSpec);
   let pageHTML = await getPageHTML(spec, pathToSpec, options);
 
@@ -201,10 +202,11 @@ async function serve(port: number, pathToSpec: string, staticFolder: string,  op
         'Content-Type': 'application/json',
       });
     } else {
-      if (staticFolder !== '' && request.url.split('/').shift() === staticFolder) {
+      if (options.static && options.static !== '' && request.url?.startsWith('/' + options.static)) {
         const filePath = join(dirname(pathToSpec), request.url);
         const fileExists = existsSync(filePath);
         if (fileExists) {
+
           respondWithGzip(
             createReadStream(filePath, 'utf8'),
             request,

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -226,6 +226,11 @@
         "handlebars": "*"
       }
     },
+    "@types/mime-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
+      "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM="
+    },
     "@types/mkdirp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
@@ -1045,6 +1050,19 @@
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
       }
     },
     "minimalistic-assert": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -11,9 +11,11 @@
     "node": ">= 8"
   },
   "dependencies": {
+    "@types/mime-types": "^2.1.0",
     "chokidar": "^3.4.1",
     "handlebars": "^4.7.6",
     "isarray": "^2.0.5",
+    "mime-types": "^2.1.27",
     "mkdirp": "^1.0.4",
     "mobx": "^4.2.0",
     "node-libs-browser": "^2.2.1",


### PR DESCRIPTION
> Firstly - great thanks to all Redoc developers for making this tool, it is super awesome!

### What changes

This PR adds possibility to serve a static folder when `redoc-cli` runs in `serve` mode.

```redoc-cli serve --help
redoc-cli serve <spec>

start the server

Positionals:
  spec  path or URL to your spec                                      [required]

Options:
  --help             Show help                                         [boolean]
  --version          Show version number                               [boolean]
  -t, --template     Path to handlebars page template, see https://git.io/vh8fP
                     for the example                                    [string]
  --templateOptions  Additional options that you want pass to template. Use dot
                     notation, e.g. templateOptions.metaDescription
  --options          ReDoc options, use dot notation, e.g.
                     options.nativeScrollbars
  --title            Page Title                                         [string]
  -s, --ssr          Enable server-side rendering                      [boolean]
  -p, --port                                            [number] [default: 8080]
  -w, --watch                                                          [boolean]
  --static           Add folder to be served statically                 [string]
```

#### Motivation

Redoc supports the `externalValue` property of examples, but if you put a local file path in there it won't work because it is being requested from client-side. The `serve` command runs a very simple HTTP server that only serves selected files, so such a request to local file is rejected with HTTP 404.

With the proposed change you can do something like this:

```json
"examples": {
    "example1": {
        "summary": "First example",
        "externalValue": "resources/examples/firstExample.json"
    },
    "example2": {
        "summary": "Second example",
        "externalValue": "resources/examples/secondExample.json"
    }
}
```

`redoc-cli serve swagger.json --watch --static resources`

The path is resolved relative to the swagger file location, so the in the above example the folder `resources` is placed next to the `swagger.json` file.

When viewing `http://127.0.0.1:8080` the files load correctly.

When bundling, redoc simply puts whatever is in `externalValue` into a `href` of a link, therefore if the `resource` folder is copied to a web server along with the `redoc-static.html`, everything will still work fine.

