### PR TITLE
Add field constraint indicator for uniqueItems

### DIFF
--- a/src/components/Fields/FieldContstraints.tsx
+++ b/src/components/Fields/FieldContstraints.tsx
@@ -14,7 +14,7 @@ export class ConstraintsView extends React.PureComponent<ConstraintsViewProps> {
       <span>
         {' '}
         {this.props.constraints.map(constraint => (
-          <ConstraintItem key={constraint}>{constraint}</ConstraintItem>
+          <ConstraintItem key={constraint}> {constraint} </ConstraintItem>
         ))}
       </span>
     );

--- a/src/components/Fields/FieldContstraints.tsx
+++ b/src/components/Fields/FieldContstraints.tsx
@@ -14,7 +14,7 @@ export class ConstraintsView extends React.PureComponent<ConstraintsViewProps> {
       <span>
         {' '}
         {this.props.constraints.map(constraint => (
-          <ConstraintItem key={constraint}> {constraint} </ConstraintItem>
+          <ConstraintItem key={constraint}>{constraint}</ConstraintItem>
         ))}
       </span>
     );

--- a/src/utils/__tests__/openapi.test.ts
+++ b/src/utils/__tests__/openapi.test.ts
@@ -335,7 +335,8 @@ describe('Utils', () => {
       min: number | undefined = undefined,
       max: number | undefined = undefined,
       multipleOf: number | undefined = undefined,
-    ) => ({ type: 'array', minItems: min, maxItems: max, multipleOf });
+      uniqueItems?: boolean,
+    ) => ({ type: 'array', minItems: min, maxItems: max, multipleOf, uniqueItems });
 
     it('should not have a humanized constraint without schema constraints', () => {
       expect(humanizeConstraints(itemConstraintSchema())).toHaveLength(0);
@@ -370,6 +371,12 @@ describe('Utils', () => {
     it('should have a humanized constraint when multipleOf is set, and it is in format other than /^0\\.0*1$/', () => {
       expect(humanizeConstraints(itemConstraintSchema(undefined, undefined, 0.5))).toContain(
         'multiple of 0.5',
+      );
+    });
+
+    it('should have a humanized constraint when uniqueItems is set', () => {
+      expect(humanizeConstraints(itemConstraintSchema(undefined, undefined, undefined, true))).toContain(
+        'unique',
       );
     });
   });

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -448,6 +448,10 @@ export function humanizeConstraints(schema: OpenAPISchema): string[] {
     res.push(numberRange);
   }
 
+  if (schema.uniqueItems) {
+    res.push('unique');
+  }
+
   return res;
 }
 


### PR DESCRIPTION
Hello,

Fixes #1353.

Schemas which define `uniqueItems` should now generate a field constraint indicator.

For the example provided in the linked issue, the visual output looks like the following:

![Screenshot from 2020-10-18 09-42-51](https://user-images.githubusercontent.com/43751307/96357075-2068c300-1129-11eb-84e6-f3268a500584.png)

---
I also noticed `ArraySchema` tries to indicate array-type constraints. Specifically, it only covers the `minItems` and `maxItems` constraints.

https://github.com/Redocly/redoc/blob/1fdfd1353dfc07aca5f5d55e5e2195648bde6e2b/src/components/Schema/ArraySchema.tsx#L21

I haven't dug too deeply into this, but with a simple schema such as:

```yaml
type: array
  items:
    type: number
  minItems: 1
```

I'd expect to see something like the following (based on the code), but I don't:

![Screenshot from 2020-10-18 10-13-56](https://user-images.githubusercontent.com/43751307/96357187-04feb780-112b-11eb-8861-049d33d82415.png)

Anyway, I'm happy to follow-up and do something about the latter if it's indeed unexpected behaviour.