### PR TITLE
Fixed the name of the OpenID Connect security scheme

### DIFF
--- a/src/components/SecuritySchemes/SecuritySchemes.tsx
+++ b/src/components/SecuritySchemes/SecuritySchemes.tsx
@@ -12,7 +12,7 @@ const AUTH_TYPES = {
   oauth2: 'OAuth2',
   apiKey: 'API Key',
   http: 'HTTP',
-  openIdConnect: 'Open ID Connect',
+  openIdConnect: 'OpenID Connect',
 };
 
 export interface OAuthFlowProps {


### PR DESCRIPTION
The official name of the OpenID Connect security scheme does not contain a space between 'Open' and 'ID', see https://openid.net/connect/.