### PR TITLE
Changed label on response sample media type dropdown to be more infor…

### DIFF
--- a/src/components/MediaTypeSwitch/MediaTypesSwitch.tsx
+++ b/src/components/MediaTypeSwitch/MediaTypesSwitch.tsx
@@ -43,7 +43,7 @@ export class MediaTypesSwitch extends React.Component<MediaTypesSwitchProps> {
     const Wrapper = ({ children }) =>
       this.props.withLabel ? (
         <DropdownWrapper>
-          <DropdownLabel>Content type</DropdownLabel>
+          <DropdownLabel>Content Type / Accept</DropdownLabel>
           {children}
         </DropdownWrapper>
       ) : (


### PR DESCRIPTION
…mative.

See Issue #1468

Redoc documentation is discovered by a ton of novice programmers. When calling the relevant API they will be trying to set all the headers correctly so redoc should aim to make this as easy as possible.

To get a response back with the correct Content-Type from the server, the user often has to set the Accept header on their request. However in the MediaTypesSwitch component the sample responses are only listed under Content-Type. This makes it very unclear that the user must set the Accept header.
![Screenshot 2020-11-22 003835](https://user-images.githubusercontent.com/22603543/99890825-1885cc80-2c5b-11eb-85eb-cbe048fec4d0.jpg)
Believe me. I spent like an hour trying to work this issue out.

This issue is compounded by the fact that the OpenAI3 spec doesn't allow putting Content-Type in the "headers" section of the response option, and most people don't put Accept in that section either.

As a solution I suggest changing the label in DropdownLabel in /src/components/MediaTypeSwitch/MediaTypesSwitch.tsx to say Content Type / Accept. It is still accurate and might save a lot of frustration amongst users of the service.

In this branch I made that change, and here is what it looks like on the demo website:
![Screenshot 2020-11-22 023102](https://user-images.githubusercontent.com/22603543/99892241-de242b80-2c6a-11eb-87c9-0fc78b9f5e43.jpg)
