### PR TITLE
fix 1248: parse json theme string for standalone tag

### DIFF
--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -32,13 +32,8 @@ function parseOptionsFromElement(element: Element) {
   const res = {};
   for (const attrName in attrMap) {
     const optionName = attrName.replace(/-(.)/g, (_, $1) => $1.toUpperCase());
-    let attr = attrMap[attrName];
-
-    if (attrName === 'theme') {
-      attr = JSON.parse(attr);
-    }
-
-    res[optionName] = attr;
+    const attr = attrMap[attrName];
+    res[optionName] = attrName === 'theme' ? JSON.parse(attr) : attr;
     // TODO: normalize options
   }
   return res;

--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -32,8 +32,8 @@ function parseOptionsFromElement(element: Element) {
   const res = {};
   for (const attrName in attrMap) {
     const optionName = attrName.replace(/-(.)/g, (_, $1) => $1.toUpperCase());
-    const attr = attrMap[attrName];
-    res[optionName] = attrName === 'theme' ? JSON.parse(attr) : attr;
+    const optionValue = attrMap[attrName];
+    res[optionName] = attrName === 'theme' ? JSON.parse(optionValue) : optionValue;
     // TODO: normalize options
   }
   return res;

--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -32,7 +32,13 @@ function parseOptionsFromElement(element: Element) {
   const res = {};
   for (const attrName in attrMap) {
     const optionName = attrName.replace(/-(.)/g, (_, $1) => $1.toUpperCase());
-    res[optionName] = attrMap[attrName];
+    let attr = attrMap[attrName];
+
+    if (attrName === 'theme') {
+      attr = JSON.parse(attr);
+    }
+
+    res[optionName] = attr;
     // TODO: normalize options
   }
   return res;


### PR DESCRIPTION
Hi,
this PR fixes the problem described in #1248, by parsing the theme string as json.

Example:
```
<html>

<body>
  <redoc spec-url="../demo/openapi.yaml" native-scrollbars theme='{"colors": {"primary": { "main": "#FF5733"}}}'></redoc>
  <script src="../bundles/redoc.standalone.js"></script>
</body>

</html>
```