### PR TITLE
Optionally render object schema title and descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ You can use all of the following options with standalone version on <redoc> tag 
 * `hideDownloadButton` - do not show "Download" spec button. **THIS DOESN'T MAKE YOUR SPEC PRIVATE**, it just hides the button.
 * `hideHostname` - if set, the protocol and hostname is not shown in the operation definition.
 * `hideLoading` - do not show loading animation. Useful for small docs.
+* `hideObjectTitle` - do not show object title in the schema.
+* `hideObjectDescription` - do not show object description in the schema.
 * `hideSchemaPattern` - if set, the pattern is not shown in the schema. 
 * `hideSingleRequestSampleTab` - do not show the request sample tab for requests with only one sample.
 * `expandSingleSchemaField` - automatically expand single field in a schema

--- a/src/common-elements/fields-layout.ts
+++ b/src/common-elements/fields-layout.ts
@@ -3,12 +3,6 @@
 import styled, { extensionsHook, media } from '../styled-components';
 import { deprecatedCss } from './mixins';
 
-export const PropertiesTableCaption = styled.caption`
-  text-align: right;
-  font-size: 0.9em;
-  font-weight: normal;
-  color: ${props => props.theme.colors.text.secondary};
-`;
 
 export const PropertyCell = styled.td<{ kind?: string }>`
   border-left: 1px solid ${props => props.theme.schema.linesColor};

--- a/src/components/Fields/Field.tsx
+++ b/src/components/Fields/Field.tsx
@@ -93,7 +93,7 @@ export class Field extends React.Component<FieldProps> {
                   schema={field.schema}
                   skipReadOnly={this.props.skipReadOnly}
                   skipWriteOnly={this.props.skipWriteOnly}
-                  showTitle={this.props.showTitle}
+                  hideObjectTitle={this.props.hideObjectTitle}
                 />
               </InnerPropertiesWrap>
             </PropertyCellWithInner>

--- a/src/components/Fields/Field.tsx
+++ b/src/components/Fields/Field.tsx
@@ -94,6 +94,7 @@ export class Field extends React.Component<FieldProps> {
                   skipReadOnly={this.props.skipReadOnly}
                   skipWriteOnly={this.props.skipWriteOnly}
                   hideObjectTitle={this.props.hideObjectTitle}
+                  hideObjectDescription={this.props.hideObjectDescription}
                 />
               </InnerPropertiesWrap>
             </PropertyCellWithInner>

--- a/src/components/Parameters/Parameters.tsx
+++ b/src/components/Parameters/Parameters.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { DropdownOrLabel } from '../DropdownOrLabel/DropdownOrLabel';
 import { ParametersGroup } from './ParametersGroup';
+import { OptionsContext } from '../OptionsProvider';
 
 import { UnderlinedHeader } from '../../common-elements';
 
@@ -26,6 +27,8 @@ export interface ParametersProps {
 const PARAM_PLACES = ['path', 'query', 'cookie', 'header'];
 
 export class Parameters extends React.PureComponent<ParametersProps> {
+  static contextType = OptionsContext;
+
   orderParams(params: FieldModel[]): Record<string, FieldModel[]> {
     const res = {};
     params.forEach(param => {
@@ -35,6 +38,7 @@ export class Parameters extends React.PureComponent<ParametersProps> {
   }
 
   render() {
+    const { hideObjectTitle, hideObjectDescription } = this.context;
     const { body, parameters = [] } = this.props;
     if (body === undefined && parameters === undefined) {
       return null;
@@ -50,10 +54,17 @@ export class Parameters extends React.PureComponent<ParametersProps> {
 
     return (
       <>
-        {paramsPlaces.map(place => (
+        {paramsPlaces.map((place) => (
           <ParametersGroup key={place} place={place} parameters={paramsMap[place]} />
         ))}
-        {bodyContent && <BodyContent content={bodyContent} description={bodyDescription} />}
+        {bodyContent && (
+          <BodyContent
+            hideObjectTitle={hideObjectTitle}
+            hideObjectDescription={hideObjectDescription}
+            content={bodyContent}
+            description={bodyDescription}
+          />
+        )}
       </>
     );
   }
@@ -67,15 +78,26 @@ function DropdownWithinHeader(props) {
   );
 }
 
-export function BodyContent(props: { content: MediaContentModel; description?: string }): JSX.Element {
-  const { content, description } = props;
+export function BodyContent(props: {
+  content: MediaContentModel;
+  description?: string;
+  hideObjectTitle?: boolean;
+  hideObjectDescription?: boolean;
+}): JSX.Element {
+  const { content, description, hideObjectTitle, hideObjectDescription } = props;
   return (
     <MediaTypesSwitch content={content} renderDropdown={DropdownWithinHeader}>
       {({ schema }) => {
         return (
           <>
             {description !== undefined && <Markdown source={description} />}
-            <Schema skipReadOnly={true} key="schema" schema={schema} />
+            <Schema
+              skipReadOnly={true}
+              hideObjectTitle={hideObjectTitle}
+              hideObjectDescription={hideObjectDescription}
+              key="schema"
+              schema={schema}
+            />
           </>
         );
       }}

--- a/src/components/Responses/ResponseDetails.tsx
+++ b/src/components/Responses/ResponseDetails.tsx
@@ -9,9 +9,13 @@ import { Schema } from '../Schema';
 
 import { Markdown } from '../Markdown/Markdown';
 import { ResponseHeaders } from './ResponseHeaders';
+import { OptionsContext } from '../OptionsProvider';
 
 export class ResponseDetails extends React.PureComponent<{ response: ResponseModel }> {
+  static contextType = OptionsContext;
+
   render() {
+    const { hideObjectTitle, hideObjectDescription } = this.context;
     const { description, headers, content } = this.props.response;
     return (
       <>
@@ -19,7 +23,11 @@ export class ResponseDetails extends React.PureComponent<{ response: ResponseMod
         <ResponseHeaders headers={headers} />
         <MediaTypesSwitch content={content} renderDropdown={this.renderDropdown}>
           {({ schema }) => {
-            return <Schema skipWriteOnly={true} key="schema" schema={schema} />;
+            return <Schema
+              skipWriteOnly={true}
+              hideObjectTitle={hideObjectTitle}
+              hideObjectDescription={hideObjectDescription}
+              key="schema" schema={schema} />;
           }}
         </MediaTypesSwitch>
       </>

--- a/src/components/Schema/ObjectSchema.tsx
+++ b/src/components/Schema/ObjectSchema.tsx
@@ -98,6 +98,8 @@ export class ObjectSchema extends React.Component<ObjectSchemaProps> {
                   showExamples={false}
                   skipReadOnly={this.props.skipReadOnly}
                   skipWriteOnly={this.props.skipWriteOnly}
+                  hideObjectTitle={this.props.hideObjectTitle}
+                  hideObjectDescription={this.props.hideObjectDescription}
                 />
               );
             })}

--- a/src/components/Schema/ObjectSchema.tsx
+++ b/src/components/Schema/ObjectSchema.tsx
@@ -1,9 +1,13 @@
 import { observer } from 'mobx-react';
 import * as React from 'react';
 
+import styled from '../../styled-components';
+
 import { SchemaModel } from '../../services/models';
 
-import { PropertiesTable, PropertiesTableCaption } from '../../common-elements/fields-layout';
+import { H3 } from '../../common-elements/headers';
+import { Markdown } from '../Markdown/Markdown';
+import { PropertiesTable } from '../../common-elements/fields-layout';
 import { Field } from '../Fields/Field';
 import { DiscriminatorDropdown } from './DiscriminatorDropdown';
 import { SchemaProps } from './Schema';
@@ -18,6 +22,18 @@ export interface ObjectSchemaProps extends SchemaProps {
   };
 }
 
+export const ObjectSchemaDetails = styled.div`
+  margin: 0 0 0.5em 0;
+`;
+
+export const ObjectSchemaTitle = styled(H3)`
+  margin: 0.5em 0 0 0;
+`;
+
+export const ObjectSchemaDescription = styled.div`
+  margin: 0.5em 0 0 0;
+`;
+
 @observer
 export class ObjectSchema extends React.Component<ObjectSchemaProps> {
   static contextType = OptionsContext;
@@ -29,7 +45,6 @@ export class ObjectSchema extends React.Component<ObjectSchemaProps> {
   render() {
     const {
       schema: { fields = [] },
-      showTitle,
       discriminator,
     } = this.props;
 
@@ -37,47 +52,58 @@ export class ObjectSchema extends React.Component<ObjectSchemaProps> {
 
     const filteredFields = needFilter
       ? fields.filter(item => {
-          return !(
-            (this.props.skipReadOnly && item.schema.readOnly) ||
-            (this.props.skipWriteOnly && item.schema.writeOnly)
-          );
-        })
+        return !(
+          (this.props.skipReadOnly && item.schema.readOnly) ||
+          (this.props.skipWriteOnly && item.schema.writeOnly)
+        );
+      })
       : fields;
 
     const expandByDefault = this.context.expandSingleSchemaField && filteredFields.length === 1;
 
     return (
-      <PropertiesTable>
-        {showTitle && <PropertiesTableCaption>{this.props.schema.title}</PropertiesTableCaption>}
-        <tbody>
-          {mapWithLast(filteredFields, (field, isLast) => {
-            return (
-              <Field
-                key={field.name}
-                isLast={isLast}
-                field={field}
-                expandByDefault={expandByDefault}
-                renderDiscriminatorSwitch={
-                  (discriminator &&
-                    discriminator.fieldName === field.name &&
-                    (() => (
-                      <DiscriminatorDropdown
-                        parent={this.parentSchema}
-                        enumValues={field.schema.enum}
-                      />
-                    ))) ||
-                  undefined
-                }
-                className={field.expanded ? 'expanded' : undefined}
-                showExamples={false}
-                skipReadOnly={this.props.skipReadOnly}
-                skipWriteOnly={this.props.skipWriteOnly}
-                showTitle={this.props.showTitle}
-              />
-            );
-          })}
-        </tbody>
-      </PropertiesTable>
+      <div>
+        <ObjectSchemaDetails>
+          {!this.props.hideObjectTitle && (
+            <ObjectSchemaTitle>{this.props.schema.title}</ObjectSchemaTitle>
+          )}
+          {!this.props.hideObjectDescription && (
+            <ObjectSchemaDescription>
+              <Markdown compact={true} source={this.props.schema.description} />
+            </ObjectSchemaDescription>
+          )}
+        </ObjectSchemaDetails>
+
+        <PropertiesTable>
+          <tbody>
+            {mapWithLast(filteredFields, (field, isLast) => {
+              return (
+                <Field
+                  key={field.name}
+                  isLast={isLast}
+                  field={field}
+                  expandByDefault={expandByDefault}
+                  renderDiscriminatorSwitch={
+                    (discriminator &&
+                      discriminator.fieldName === field.name &&
+                      (() => (
+                        <DiscriminatorDropdown
+                          parent={this.parentSchema}
+                          enumValues={field.schema.enum}
+                        />
+                      ))) ||
+                    undefined
+                  }
+                  className={field.expanded ? 'expanded' : undefined}
+                  showExamples={false}
+                  skipReadOnly={this.props.skipReadOnly}
+                  skipWriteOnly={this.props.skipWriteOnly}
+                />
+              );
+            })}
+          </tbody>
+        </PropertiesTable>
+      </div>
     );
   }
 }

--- a/src/components/Schema/Schema.tsx
+++ b/src/components/Schema/Schema.tsx
@@ -13,9 +13,10 @@ import { OneOfSchema } from './OneOfSchema';
 import { l } from '../../services/Labels';
 
 export interface SchemaOptions {
-  showTitle?: boolean;
   skipReadOnly?: boolean;
   skipWriteOnly?: boolean;
+  hideObjectTitle?: boolean;
+  hideObjectDescription?: boolean;
 }
 
 export interface SchemaProps extends SchemaOptions {

--- a/src/components/SchemaDefinition/SchemaDefinition.tsx
+++ b/src/components/SchemaDefinition/SchemaDefinition.tsx
@@ -14,6 +14,8 @@ export interface ObjectDescriptionProps {
   exampleRef?: string;
   showReadOnly?: boolean;
   showWriteOnly?: boolean;
+  showObjectTitle?: boolean;
+  showObjectDescription?: boolean;
   parser: OpenAPIParser;
   options: RedocNormalizedOptions;
 }
@@ -53,7 +55,12 @@ export class SchemaDefinition extends React.PureComponent<ObjectDescriptionProps
   }
 
   render() {
-    const { showReadOnly = true, showWriteOnly = false } = this.props;
+    const {
+      showReadOnly = true,
+      showWriteOnly = false,
+      showObjectTitle = false,
+      showObjectDescription = false,
+    } = this.props;
     return (
       <Section>
         <Row>
@@ -61,6 +68,8 @@ export class SchemaDefinition extends React.PureComponent<ObjectDescriptionProps
             <Schema
               skipWriteOnly={!showWriteOnly}
               skipReadOnly={!showReadOnly}
+              hideObjectTitle={!showObjectTitle}
+              hideObjectDescription={!showObjectDescription}
               schema={this.mediaModel.schema}
             />
           </MiddlePanel>

--- a/src/components/__tests__/__snapshots__/DiscriminatorDropdown.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DiscriminatorDropdown.test.tsx.snap
@@ -1,109 +1,122 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components SchemaView discriminator should correctly render discriminator dropdown 1`] = `
-<styled.table>
-  <tbody>
-    <Field
-      field={
-        FieldModel {
-          "deprecated": false,
-          "description": "",
-          "example": undefined,
-          "expanded": false,
-          "explode": false,
-          "in": undefined,
-          "kind": "field",
-          "name": "packSize",
-          "required": false,
-          "schema": SchemaModel {
-            "activeOneOf": 0,
-            "constraints": Array [],
-            "default": undefined,
+<div>
+  <styled.div>
+    <Styled(styled.h2)>
+      Dog
+    </Styled(styled.h2)>
+    <styled.div>
+      <Markdown
+        compact={true}
+        source=""
+      />
+    </styled.div>
+  </styled.div>
+  <styled.table>
+    <tbody>
+      <Field
+        field={
+          FieldModel {
             "deprecated": false,
             "description": "",
-            "displayFormat": undefined,
-            "displayType": "number",
-            "enum": Array [],
             "example": undefined,
-            "externalDocs": undefined,
-            "format": undefined,
-            "isCircular": undefined,
-            "isPrimitive": true,
-            "nullable": false,
-            "options": "<<<filtered>>>",
-            "pattern": undefined,
-            "pointer": "#/components/schemas/Dog/properties/packSize",
-            "rawSchema": Object {
+            "expanded": false,
+            "explode": false,
+            "in": undefined,
+            "kind": "field",
+            "name": "packSize",
+            "required": false,
+            "schema": SchemaModel {
+              "activeOneOf": 0,
+              "constraints": Array [],
               "default": undefined,
+              "deprecated": false,
+              "description": "",
+              "displayFormat": undefined,
+              "displayType": "number",
+              "enum": Array [],
+              "example": undefined,
+              "externalDocs": undefined,
+              "format": undefined,
+              "isCircular": undefined,
+              "isPrimitive": true,
+              "nullable": false,
+              "options": "<<<filtered>>>",
+              "pattern": undefined,
+              "pointer": "#/components/schemas/Dog/properties/packSize",
+              "rawSchema": Object {
+                "default": undefined,
+                "type": "number",
+              },
+              "readOnly": false,
+              "schema": Object {
+                "default": undefined,
+                "type": "number",
+              },
+              "title": "",
               "type": "number",
+              "typePrefix": "",
+              "writeOnly": false,
             },
-            "readOnly": false,
-            "schema": Object {
-              "default": undefined,
-              "type": "number",
-            },
-            "title": "",
-            "type": "number",
-            "typePrefix": "",
-            "writeOnly": false,
-          },
+          }
         }
-      }
-      isLast={false}
-      key="packSize"
-      showExamples={false}
-    />
-    <Field
-      field={
-        FieldModel {
-          "deprecated": false,
-          "description": "",
-          "example": undefined,
-          "expanded": false,
-          "explode": false,
-          "in": undefined,
-          "kind": "field",
-          "name": "type",
-          "required": true,
-          "schema": SchemaModel {
-            "activeOneOf": 0,
-            "constraints": Array [],
-            "default": undefined,
+        isLast={false}
+        key="packSize"
+        showExamples={false}
+      />
+      <Field
+        field={
+          FieldModel {
             "deprecated": false,
             "description": "",
-            "displayFormat": undefined,
-            "displayType": "string",
-            "enum": Array [],
             "example": undefined,
-            "externalDocs": undefined,
-            "format": undefined,
-            "isCircular": undefined,
-            "isPrimitive": true,
-            "nullable": false,
-            "options": "<<<filtered>>>",
-            "pattern": undefined,
-            "pointer": "#/components/schemas/Dog/properties/type",
-            "rawSchema": Object {
+            "expanded": false,
+            "explode": false,
+            "in": undefined,
+            "kind": "field",
+            "name": "type",
+            "required": true,
+            "schema": SchemaModel {
+              "activeOneOf": 0,
+              "constraints": Array [],
               "default": undefined,
+              "deprecated": false,
+              "description": "",
+              "displayFormat": undefined,
+              "displayType": "string",
+              "enum": Array [],
+              "example": undefined,
+              "externalDocs": undefined,
+              "format": undefined,
+              "isCircular": undefined,
+              "isPrimitive": true,
+              "nullable": false,
+              "options": "<<<filtered>>>",
+              "pattern": undefined,
+              "pointer": "#/components/schemas/Dog/properties/type",
+              "rawSchema": Object {
+                "default": undefined,
+                "type": "string",
+              },
+              "readOnly": false,
+              "schema": Object {
+                "default": undefined,
+                "type": "string",
+              },
+              "title": "",
               "type": "string",
+              "typePrefix": "",
+              "writeOnly": false,
             },
-            "readOnly": false,
-            "schema": Object {
-              "default": undefined,
-              "type": "string",
-            },
-            "title": "",
-            "type": "string",
-            "typePrefix": "",
-            "writeOnly": false,
-          },
+          }
         }
-      }
-      isLast={true}
-      key="type"
-      renderDiscriminatorSwitch={[Function]}
-      showExamples={false}
-    />
-  </tbody>
-</styled.table>
+        isLast={true}
+        key="type"
+        renderDiscriminatorSwitch={[Function]}
+        showExamples={false}
+      />
+    </tbody>
+  </styled.table>
+</div>
 `;

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -29,6 +29,8 @@ export interface RedocRawOptions {
   simpleOneOfTypeLabel?: boolean | string;
   payloadSampleIdx?: number;
   expandSingleSchemaField?: boolean | string;
+  hideObjectTitle?: boolean | string;
+  hideObjectDescription?: boolean | string;
 
   unstable_ignoreMimeParameters?: boolean;
 
@@ -186,6 +188,8 @@ export class RedocNormalizedOptions {
   simpleOneOfTypeLabel: boolean;
   payloadSampleIdx: number;
   expandSingleSchemaField: boolean;
+  hideObjectTitle: boolean;
+  hideObjectDescription: boolean;
 
   /* tslint:disable-next-line */
   unstable_ignoreMimeParameters: boolean;
@@ -245,6 +249,8 @@ export class RedocNormalizedOptions {
     this.simpleOneOfTypeLabel = argValueToBoolean(raw.simpleOneOfTypeLabel);
     this.payloadSampleIdx = RedocNormalizedOptions.normalizePayloadSampleIdx(raw.payloadSampleIdx);
     this.expandSingleSchemaField = argValueToBoolean(raw.expandSingleSchemaField);
+    this.hideObjectTitle = argValueToBoolean(raw.hideObjectTitle);
+    this.hideObjectDescription = argValueToBoolean(raw.hideObjectDescription);
 
     this.unstable_ignoreMimeParameters = argValueToBoolean(raw.unstable_ignoreMimeParameters);
 


### PR DESCRIPTION
It's a followup of #1035. Fixes #598, #720.

Shown in operations but hidden in \<SchemaDefinition\> by default.

Before the fix:
![Selection_012](https://user-images.githubusercontent.com/271538/104303820-889b2b00-5505-11eb-83e4-e3872ba399bc.png)

After the fix:
![Selection_013](https://user-images.githubusercontent.com/271538/104303840-8e910c00-5505-11eb-8cbb-e08e6744b795.png)
