### PR TITLE
Quick fix for #1463: Example drop down cuts off text

### DIFF
--- a/src/common-elements/dropdown.ts
+++ b/src/common-elements/dropdown.ts
@@ -43,9 +43,7 @@ export const StyledDropdown = styled(Dropdown)`
       display: inline-flex;
       padding: 0;
       height: auto;
-      padding-right: 20px;
       position: relative;
-      margin-bottom: 5px;
     }
     .dropdown-selector-value {
       font-family: ${(props) => props.theme.typography.headings.fontFamily};
@@ -59,14 +57,12 @@ export const StyledDropdown = styled(Dropdown)`
       transition: color 0.25s ease, text-shadow 0.25s ease;
     }
     .dropdown-arrow {
-      position: absolute;
-      right: 3px;
-      top: 50%;
-      transform: translateY(-50%);
+      position: static;
       border-color: ${(props) => props.theme.colors.primary.main} transparent transparent;
       border-style: solid;
       border-width: 0.35em 0.35em 0;
       width: 0;
+      height: 0;
       svg {
         display: none;
       }

--- a/src/common-elements/dropdown.ts
+++ b/src/common-elements/dropdown.ts
@@ -52,7 +52,7 @@ export const StyledDropdown = styled(Dropdown)`
       position: relative;
       font-size: 0.929em;
       width: 100%;
-      line-height: 1;
+      line-height: normal;
       vertical-align: middle;
       color: #263238;
       left: 0;


### PR DESCRIPTION
Hi,
this is a quick fix for #1463 styling issue by setting value container line height to `normal`.

It looks like the dropdown component may have some search capabilities, which may be impacted by this change. Please point me to the page where I can spot it in the wild to test.

Also running `npm run prettier` (as per contribution guidelines), introduced a huge 72 files change, so I'm leaving mine without it for brevity.