### PR TITLE
Add options to sort tags,operations and groups alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ You can use all of the following options with standalone version on <redoc> tag 
   * **function**: A getter function. Must return a number representing the offset (in pixels).
 * `showExtensions` - show vendor extensions ("x-" fields). Extensions used by ReDoc are ignored. Can be boolean or an array of `string` with names of extensions to display.
 * `sortPropsAlphabetically` - sort properties alphabetically.
+* `sortTagsAlphabetically` - sort tags alphabetically.
+* `sortOperationsAlphabetically` - sort operations alphabetically.
+* `sortTagGroupsAlphabetically` - sort tag groups alphabetically.
 * `suppressWarnings` - if set, warnings are not rendered at the top of documentation (they still are logged to the console).
 * `payloadSampleIdx` - if set, payload sample will be inserted at this index or last. Indexes start from 0.
 * `theme` - ReDoc theme. For details check [theme docs](#redoc-theme-object).

--- a/src/services/AppStore.ts
+++ b/src/services/AppStore.ts
@@ -81,7 +81,7 @@ export class AppStore {
     MenuStore.updateOnHistory(history.currentId, this.scroll);
 
     this.spec = new SpecStore(spec, specUrl, this.options);
-    this.menu = new MenuStore(this.spec, this.scroll, history);
+    this.menu = new MenuStore(this.spec, this.scroll, history, this.options);
 
     if (!this.options.disableSearch) {
       this.search = new SearchStore();

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -13,6 +13,9 @@ export interface RedocRawOptions {
   requiredPropsFirst?: boolean | string;
   sortPropsAlphabetically?: boolean | string;
   sortEnumValuesAlphabetically?: boolean | string;
+  sortTagGroupsAlphabetically?: boolean | string;
+  sortTagsAlphabetically?: boolean | string;
+  sortOperationsAlphabetically?: boolean | string;
   noAutoAuth?: boolean | string;
   nativeScrollbars?: boolean | string;
   pathInMiddlePanel?: boolean | string;
@@ -170,6 +173,9 @@ export class RedocNormalizedOptions {
   requiredPropsFirst: boolean;
   sortPropsAlphabetically: boolean;
   sortEnumValuesAlphabetically: boolean;
+  sortTagGroupsAlphabetically: boolean;
+  sortTagsAlphabetically: boolean;
+  sortOperationsAlphabetically: boolean;
   noAutoAuth: boolean;
   nativeScrollbars: boolean;
   pathInMiddlePanel: boolean;
@@ -227,6 +233,9 @@ export class RedocNormalizedOptions {
     this.requiredPropsFirst = argValueToBoolean(raw.requiredPropsFirst);
     this.sortPropsAlphabetically = argValueToBoolean(raw.sortPropsAlphabetically);
     this.sortEnumValuesAlphabetically = argValueToBoolean(raw.sortEnumValuesAlphabetically);
+    this.sortTagGroupsAlphabetically = argValueToBoolean(raw.sortTagGroupsAlphabetically);
+    this.sortTagsAlphabetically = argValueToBoolean(raw.sortTagsAlphabetically);
+    this.sortOperationsAlphabetically = argValueToBoolean(raw.sortOperationsAlphabetically);
     this.noAutoAuth = argValueToBoolean(raw.noAutoAuth);
     this.nativeScrollbars = argValueToBoolean(raw.nativeScrollbars);
     this.pathInMiddlePanel = argValueToBoolean(raw.pathInMiddlePanel);


### PR DESCRIPTION
Note: I did test that it behaves correctly when the if clauses are manually set to true, however wasn't able to test the options work since there doesn't seem any easy way to change options in the devserver or build `redoc-cli` using local redoc (at least as far as I could tell, some contribution documentation would be nice) 