### PR TITLE
Set styled-componenets version to 5.2.1 until `ReferenceError: window is not defined` is fixed

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -20,7 +20,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "redoc": "2.0.0-rc.50",
-    "styled-components": "^5.1.1",
+    "styled-components": "5.2.1",
     "tslib": "^2.0.0",
     "yargs": "^15.4.1"
   },


### PR DESCRIPTION
Issue page: #1563 

The `redoc-cli bundle` does not work with the 5.2.2 version of styled-components, while the `serve` works normally which is expected 
