### PR TITLE
Added missing semicolon

### DIFF
--- a/src/components/Markdown/styled.elements.tsx
+++ b/src/components/Markdown/styled.elements.tsx
@@ -87,7 +87,7 @@ export const StyledMarkdownBlock = styled(
     padding: ${props => props.theme.spacing.unit * 4}px;
     overflow-x: auto;
     line-height: normal;
-    border-radius: 0px
+    border-radius: 0px;
     border: 1px solid rgba(38, 50, 56, 0.1);
 
     code {


### PR DESCRIPTION
There was a missing semicolon in the CSS. As is, it works without any issue, but if any minification happens, it can result in this:

![image](https://user-images.githubusercontent.com/1663018/114427946-9b1b1400-9b89-11eb-9757-7a5fb9113661.png)
