### PR TITLE
Improve operational summary

### DIFF
--- a/src/utils/__tests__/openapi.test.ts
+++ b/src/utils/__tests__/openapi.test.ts
@@ -101,6 +101,13 @@ describe('Utils', () => {
       expect(getOperationSummary(operation as any).length).toBe(50);
     });
 
+    it('Should return pathName if no summary, operationId, description', () => {
+      const operation = {
+        pathName: '/sandbox/test'
+      };
+      expect(getOperationSummary(operation as any)).toBe('/sandbox/test');
+    });
+
     it('Should return <no summary> if no info', () => {
       const operation = {
         description: undefined,

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -1,12 +1,12 @@
 import { dirname } from 'path';
 import * as URLtemplate from 'url-template';
 
+import { ExtendedOpenAPIOperation } from '../services';
 import { FieldModel } from '../services/models';
 import { OpenAPIParser } from '../services/OpenAPIParser';
 import {
   OpenAPIEncoding,
   OpenAPIMediaType,
-  OpenAPIOperation,
   OpenAPIParameter,
   OpenAPIParameterStyle,
   OpenAPISchema,
@@ -62,12 +62,13 @@ export function isOperationName(key: string): boolean {
   return key in operationNames;
 }
 
-export function getOperationSummary(operation: OpenAPIOperation): string {
+export function getOperationSummary(operation: ExtendedOpenAPIOperation): string {
   return (
     operation.summary ||
     operation.operationId ||
     (operation.description && operation.description.substring(0, 50)) ||
-    '<no summary>'
+    operation.pathName ||
+   '<no summary>'
   );
 }
 


### PR DESCRIPTION
resolves #1270

Show path instead of `<no summary>` in sidebar menu

![Selection_477](https://user-images.githubusercontent.com/7952949/116601086-b7ad9f00-a932-11eb-8cb5-0655ad640df8.png)

