### PR TITLE
fix: logo svg doesn't display or not a 100%

### DIFF
--- a/src/components/ApiLogo/styled.elements.tsx
+++ b/src/components/ApiLogo/styled.elements.tsx
@@ -14,7 +14,8 @@ export const LogoWrap = styled.div`
 `;
 
 const Link = styled.a`
-  display: inline-block;
+  display: flex;
+  justify-content: center;
 `;
 
 // eslint-disable-next-line react/display-name


### PR DESCRIPTION
Two issues with logo in SVG when using a link on it as the link is using `display: inline-block`:

- An SVG without height and width attributes display at 0 x 0 size
- An SVG with height and width attributes will only display at the given size and not at `width: 100%` as intended.

Fix this wrongly closed issue: https://github.com/Redocly/redoc/issues/1048