### PR TITLE
feat: add q/kdb+ syntax highlighting

### DIFF
--- a/src/utils/highlight.ts
+++ b/src/utils/highlight.ts
@@ -15,6 +15,7 @@ import 'prismjs/components/prism-objectivec.js';
 import 'prismjs/components/prism-perl.js';
 import 'prismjs/components/prism-php.js';
 import 'prismjs/components/prism-python.js';
+import 'prismjs/components/prism-q.js';
 import 'prismjs/components/prism-ruby.js';
 import 'prismjs/components/prism-scala.js';
 import 'prismjs/components/prism-sql.js';


### PR DESCRIPTION
Add q syntax highlighting support for use with `x-codeSamples`

Example below:

```
  /register:
    post:
      x-codeSamples:
        - lang: q
          source: "2 + 2 * count \"abcdef\""
```

![image](https://user-images.githubusercontent.com/3884351/117467922-10d98c00-af4c-11eb-9c90-4e196c618542.png)
