### PR TITLE
docs: remove api console from the roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@
   - [x] ~~React rewrite~~
   - [x] ~~docs pre-rendering (performance and SEO)~~
   - [ ] ability to simple branding/styling
-  - [ ] built-in API Console
 
 ## Releases
 **Important:** all the 2.x releases are deployed to npm and can be used via jsdeliver:


### PR DESCRIPTION
Remove the API Console from the roadmap, In light of the comment made here: https://github.com/Redocly/redoc/issues/53#issuecomment-576377856