### PR TITLE
Add new option maxSampleDepth

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ You can use all of the following options with standalone version on <redoc> tag 
 * `hideSchemaTitles` - do not display schema `title` next to to the type
 * `simpleOneOfTypeLabel` - show only unique oneOf types in the label without titles
 * `lazyRendering` - _Not implemented yet_ ~~if set, enables lazy rendering mode in ReDoc. This mode is useful for APIs with big number of operations (e.g. > 50). In this mode ReDoc shows initial screen ASAP and then renders the rest operations asynchronously while showing progress bar on the top. Check out the [demo](\\redocly.github.io/redoc) for the example.~~
+* `maxSampleDepth` - set the maximum render depth for JSON payload samples (responses and request body). The default value is `10`.
 * `menuToggle` - if true clicking second time on expanded menu item will collapse it, default `true`.
 * `nativeScrollbars` - use native scrollbar for sidemenu instead of perfect-scroll (scrolling performance optimization for big specs).
 * `noAutoAuth` - do not inject Authentication section automatically.

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -42,6 +42,7 @@ export interface RedocRawOptions {
   maxDisplayedEnumValues?: number;
   ignoreNamedSchemas?: string[] | string;
   hideSchemaPattern?: boolean;
+  maxSampleDepth?: number;
 }
 
 function argValueToBoolean(val?: string | boolean, defaultValue?: boolean): boolean {
@@ -163,6 +164,14 @@ export class RedocNormalizedOptions {
     return 2;
   }
 
+  private static normalizeMaxSampleDepth(value?: number | string | undefined): number {
+    if (!isNaN(Number(value))) {
+      return Math.max(0, Number(value));
+    }
+
+    return 10;
+  }
+
   theme: ResolvedThemeInterface;
   scrollYOffset: () => number;
   hideHostname: boolean;
@@ -196,6 +205,7 @@ export class RedocNormalizedOptions {
 
   ignoreNamedSchemas: Set<string>;
   hideSchemaPattern: boolean;
+  maxSampleDepth: number;
 
   constructor(raw: RedocRawOptions, defaults: RedocRawOptions = {}) {
     raw = { ...defaults, ...raw };
@@ -257,5 +267,6 @@ export class RedocNormalizedOptions {
       : raw.ignoreNamedSchemas?.split(',').map((s) => s.trim());
     this.ignoreNamedSchemas = new Set(ignoreNamedSchemas);
     this.hideSchemaPattern = argValueToBoolean(raw.hideSchemaPattern);
+    this.maxSampleDepth = RedocNormalizedOptions.normalizeMaxSampleDepth(raw.maxSampleDepth);
   }
 }

--- a/src/services/models/MediaType.ts
+++ b/src/services/models/MediaType.ts
@@ -14,6 +14,7 @@ export class MediaTypeModel {
   name: string;
   isRequestType: boolean;
   onlyRequiredInSamples: boolean;
+  maxSampleDepth: number;
 
   /**
    * @param isRequestType needed to know if skipe RO/RW fields in objects
@@ -29,6 +30,7 @@ export class MediaTypeModel {
     this.isRequestType = isRequestType;
     this.schema = info.schema && new SchemaModel(parser, info.schema, '', options);
     this.onlyRequiredInSamples = options.onlyRequiredInSamples;
+    this.maxSampleDepth = options.maxSampleDepth;
     if (info.examples !== undefined) {
       this.examples = mapValues(
         info.examples,
@@ -53,7 +55,7 @@ export class MediaTypeModel {
       skipReadOnly: this.isRequestType,
       skipNonRequired: this.isRequestType && this.onlyRequiredInSamples,
       skipWriteOnly: !this.isRequestType,
-      maxSampleDepth: 10,
+      maxSampleDepth: this.maxSampleDepth,
     };
     if (this.schema && this.schema.oneOf) {
       this.examples = {};


### PR DESCRIPTION
Parameterizes `maxSampleDepth` property for folks (like me) who would like to render deeply nested JSON payload samples beyond the default 10 levels.