### PR TITLE
chore: changed docs sync flow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -14,3 +14,5 @@ jobs:
         uses: Redocly/repo-file-sync-action@master
         with:
           GH_PAT: ${{ secrets.GH_PAT }}
+          COMMIT_PREFIX: "sync:"
+          SKIP_PR: true


### PR DESCRIPTION
## What/Why/How?

This commit adds new docs sync flow - without PR creation. New docs changes will be directly pushed into the docs repo.
