### PR TITLE
Improve the redoc cli README

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -3,20 +3,29 @@
 **[ReDoc](https://github.com/Redocly/redoc)'s Command Line Interface**
 
 ## Installation
-You can use redoc cli by installing `redoc-cli` globally or using [npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
+
+You can use `redoc-cli` by installing [the package](https://www.npmjs.com/package/redoc-cli) globally,
+or using [npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
 
 ## Usage
 
-Two following commands are available:
+The two following commands are available:
 
-- `redoc-cli serve [spec]` - starts the server with `spec` rendered with ReDoc. Supports SSR mode (`--ssr`) and can watch the spec (`--watch`)
-- `redoc-cli bundle [spec]` - bundles spec and ReDoc into **zero-dependency** HTML file.
+- `redoc-cli serve [spec]` - starts the server with `spec` rendered with ReDoc.
+  Supports a server-side rendering mode (`--ssr`),
+  and can watch the spec (`--watch`) to automatically reload the page whenever it changes.
+- `redoc-cli bundle [spec]` - bundles `spec` and ReDoc into a **zero-dependency** HTML file.
 
 Some examples:
 
-- Bundle with main color changed to `orange`: <br> `$ redoc-cli bundle [spec] --options.theme.colors.primary.main=orange`
-- Serve with `nativeScrollbars` option set to true: <br> `$ redoc-cli serve [spec] --options.nativeScrollbars`
-- Bundle using custom template (check [default template](https://github.com/Redocly/redoc/blob/master/cli/template.hbs) for reference): <br> `$ redoc-cli bundle [spec] -t custom.hbs`
-- Bundle using custom template and add custom `templateOptions`: <br> `$ redoc-cli bundle [spec] -t custom.hbs --templateOptions.metaDescription "Page meta description"`
+- Bundle with the main color changed to `orange`:<br/>
+  `$ redoc-cli bundle [spec] --options.theme.colors.primary.main=orange`
+- Serve with the `nativeScrollbars` option set to true:<br/>
+  `$ redoc-cli serve [spec] --options.nativeScrollbars`
+- Bundle using a custom [Handlebars](https://handlebarsjs.com/) template
+  (check the [default template](https://github.com/Redocly/redoc/blob/master/cli/template.hbs) for an example):<br/>
+  `$ redoc-cli bundle [spec] -t custom.hbs`
+- Bundle using a custom template and add custom `templateOptions`:<br/>
+  `$ redoc-cli bundle [spec] -t custom.hbs --templateOptions.metaDescription "Page meta description"`
 
-For more details run `redoc-cli --help`.
+For more details, run `redoc-cli --help`.


### PR DESCRIPTION
## What/Why/How?

This PR makes several small improvements to the cli/README.md file:

- Break some long lines
- Add some articles (the, a)
- Add a couple links for additional context
- Expand the SSR acronym
- Describe what the `--watch` option does
