### PR TITLE
fix: Bump npm-shrinkwrap

### DIFF
--- a/cli/npm-shrinkwrap.json
+++ b/cli/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "redoc-cli",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
This PR bumps `npm-shrinkwrap` to `v0.12.2` so that can match the already bumped `package.json`: https://github.com/Redocly/redoc/blob/master/cli/package.json#L3