### PR TITLE
fix: nullable object's fields were missing

### DIFF
--- a/src/components/Schema/Schema.tsx
+++ b/src/components/Schema/Schema.tsx
@@ -63,18 +63,13 @@ export class Schema extends React.Component<Partial<SchemaProps>> {
       return <OneOfSchema schema={schema} {...this.props} />;
     }
 
-    if (type && Array.isArray(type)) {
+    const types = Array.isArray(type) ? type : [type];
+    if (types.includes('object')) {
+      if (schema.fields?.length) {
+        return <ObjectSchema {...(this.props as any)} />;
+      }
+    } else if (types.includes('array')) {
       return <ArraySchema {...(this.props as any)} />;
-    }
-
-    switch (type) {
-      case 'object':
-        if (schema.fields?.length) {
-          return <ObjectSchema {...(this.props as any)} />;
-        }
-        break;
-      case 'array':
-        return <ArraySchema {...(this.props as any)} />;
     }
 
     // TODO: maybe adjust FieldDetails to accept schema

--- a/src/services/models/Schema.ts
+++ b/src/services/models/Schema.ts
@@ -100,6 +100,10 @@ export class SchemaModel {
     this.activeOneOf = idx;
   }
 
+  hasType(type: string) {
+    return this.type === type || (Array.isArray(this.type) && this.type.includes(type));
+  }
+
   init(parser: OpenAPIParser, isChild: boolean) {
     const schema = this.schema;
     this.isCircular = schema['x-circular-ref'];
@@ -170,9 +174,9 @@ export class SchemaModel {
       return;
     }
 
-    if (this.type === 'object') {
+    if (this.hasType('object')) {
       this.fields = buildFields(parser, schema, this.pointer, this.options);
-    } else if ((this.type === 'array' || Array.isArray(this.type)) && schema.items) {
+    } else if (this.hasType('array') && schema.items) {
       this.items = new SchemaModel(parser, schema.items, this.pointer + '/items', this.options);
       this.displayType = pluralizeType(this.items.displayType);
       this.displayFormat = this.items.format;


### PR DESCRIPTION
## What/Why/How?
When 3.1 was implemented all nullable object fields were not displayed at all, instead object or null was shown.
## Reference

## Testing
```
sub:
  description: Test Sub Category
  type: [object, null]
  properties:
    prop1:
    type: string
    description: text of description
```

## Screenshots (optional)
<img width="738" alt="Screenshot 2021-08-11 at 12 37 58" src="https://user-images.githubusercontent.com/14113673/129007931-730227ec-fd44-4c1a-b24c-139b0f041a4f.png">

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
