### PR TITLE
[GSOD]Removes content that is now in documentation and adds link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - Responsive three-panel design with menu/scrolling synchronization
 - Deep linking support
 - Ability to integrate your API introduction into the side menu
-- High-level grouping in side-menu via [`x-tagGroups`](https://redoc.ly/docs/api-reference-docs/specification-extensions/x-tag-groups/) vendor extension
+- High-level grouping in side-menu via [`x-tagGroups`](https://redoc.ly/docs/api-reference-docs/specification-extensions/x-tag-groups/) specification extension
 - Branding/customizations using the [`theme` option](https://redoc.ly/docs/api-reference-docs/configuration/theming/)
 - OpenAPI v3.0 support
 - Basic OpenAPI v3.1 support
@@ -83,8 +83,8 @@ For more information on Redoc's commmand-line interface, refer to
 You can inject the Security Definitions widget into any place in your definition `description`.
 For more information, refer to [Security definitions injection](docs/security-definitions-injection.md).
 
-### Swagger vendor extensions
-Redoc uses the following [vendor extensions](https://swagger.io/specification/#specificationExtensions):
+### OpenAPI specification extensions
+Redoc uses the following [specification extensions](https://swagger.io/specification/#specificationExtensions):
 * [`x-logo`](docs/redoc-vendor-extensions.md#x-logo) - is used to specify API logo
 * [`x-traitTag`](docs/redoc-vendor-extensions.md#x-traitTag) - useful for handling out common things like Pagination, Rate-Limits, etc
 * [`x-codeSamples`](docs/redoc-vendor-extensions.md#x-codeSamples) - specify operation code samples

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - Responsive three-panel design with menu/scrolling synchronization
 - Deep linking support
 - Ability to integrate your API introduction into the side menu
-- High-level grouping in side-menu via [`x-tagGroups`](https://redoc.ly/docs/api-reference-docs/specification-extensions/x-tag-groups/) specification extension
+- High-level grouping in side-menu with [`x-tagGroups`](https://redoc.ly/docs/api-reference-docs/specification-extensions/x-tag-groups/) specification extension
 - Branding/customizations using the [`theme` option](https://redoc.ly/docs/api-reference-docs/configuration/theming/)
 - OpenAPI v3.0 support
 - Basic OpenAPI v3.1 support

--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@
   [![Build Status](https://travis-ci.com/Redocly/redoc.svg?branch=master)](https://travis-ci.com/Redocly/redoc) [![Coverage Status](https://coveralls.io/repos/Redocly/redoc/badge.svg?branch=master&service=github)](https://coveralls.io/github/Redocly/redoc?branch=master) [![dependencies Status](https://david-dm.org/Redocly/redoc/status.svg)](https://david-dm.org/Redocly/redoc) [![devDependencies Status](https://david-dm.org/Redocly/redoc/dev-status.svg)](https://david-dm.org/Redocly/redoc#info=devDependencies) [![npm](http://img.shields.io/npm/v/redoc.svg)](https://www.npmjs.com/package/redoc) [![License](https://img.shields.io/npm/l/redoc.svg)](https://github.com/Redocly/redoc/blob/master/LICENSE)
 
   [![bundle size](http://img.badgesize.io/https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js?compression=gzip&max=300000)](https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js) [![npm](https://img.shields.io/npm/dm/redoc.svg)](https://www.npmjs.com/package/redoc) [![](https://data.jsdelivr.com/v1/package/npm/redoc/badge)](https://www.jsdelivr.com/package/npm/redoc) [![Docker Build Status](https://img.shields.io/docker/build/redocly/redoc.svg)](https://hub.docker.com/r/redocly/redoc/)
-
-
 </div>
 
-**This is README for `2.0` version of ReDoc (React based). README for `1.x` version is on the branch [v1.x](https://github.com/Redocly/redoc/tree/v1.x)**
-
+**This is the README for the `2.x` version of Redoc (React-based).** 
+**The README for the `1.x` version is on the [v1.x](https://github.com/Redocly/redoc/tree/v1.x) branch**
 
 ![ReDoc demo](https://raw.githubusercontent.com/Redocly/redoc/master/demo/redoc-demo.png)
 
@@ -20,34 +18,29 @@
 [<img alt="Deploy to Github" src="http://i.imgur.com/YZmaqk3.png" height="60px">](https://github.com/Rebilly/generator-openapi-repo#generator-openapi-repo--) [<img alt="ReDoc as a service" src="http://i.imgur.com/edqdCv6.png" height="60px">](https://redoc.ly) [<img alt="Customization services" src="http://i.imgur.com/c4sUF7M.png" height="60px">](https://redoc.ly/#services)
 
 ## Features
-- Extremely easy deployment
-- [redoc-cli](https://github.com/Redocly/redoc/blob/master/cli/README.md) with ability to bundle your docs into **zero-dependency** HTML file
-- Server Side Rendering ready
-- The widest OpenAPI v2.0 features support (yes, it supports even `discriminator`) <br>
-![](docs/images/discriminator-demo.gif)
-- OpenAPI 3.0 support
-- Basic OpenAPI 3.1 support
-- Neat **interactive** documentation for nested objects <br>
-![](docs/images/nested-demo.gif)
-- Code samples support (via vendor extension) <br>
-![](docs/images/code-samples-demo.gif)
+- [Multiple deployment options](https://redoc.ly/docs/redoc/quickstart/intro/)
+- [Server-side rendering (SSR) ready](https://redoc.ly/docs/redoc/quickstart/cli/#redoc-cli-commands)
+- [Simple integration with `create-react-app`](https://redoc.ly/docs/redoc/quickstart/react/)
+  
+  [See an example](https://github.com/APIs-guru/create-react-app-redoc)
+- [Command-line interface to bundle your docs into a **zero-dependency** HTML file](https://redoc.ly/docs/redoc/quickstart/cli/)
 - Responsive three-panel design with menu/scrolling synchronization
-- Integrate API Introduction into side menu - ReDoc takes advantage of markdown headings from OpenAPI description field. It pulls them into side menu and also supports deep linking.
-- High-level grouping in side-menu via [`x-tagGroups`](docs/redoc-vendor-extensions.md#x-tagGroups) vendor extension
-- Simple integration with `create-react-app` ([sample](https://github.com/APIs-guru/create-react-app-redoc))
-- Branding/customizations via [`theme` option](#redoc-options-object)
-
-## Roadmap
-  - [x] ~~[OpenAPI v3.0 support](https://github.com/Redocly/redoc/issues/312)~~
-  - [x] ~~performance optimizations~~
-  - [x] ~~better navigation (menu improvements + search)~~
-  - [x] ~~React rewrite~~
-  - [x] ~~docs pre-rendering (performance and SEO)~~
-  - [ ] ability to simple branding/styling
+- Deep linking support
+- Ability to integrate your API introduction into the side menu
+- High-level grouping in side-menu via [`x-tagGroups`](https://redoc.ly/docs/api-reference-docs/specification-extensions/x-tag-groups/) vendor extension
+- Branding/customizations using the [`theme` option](https://redoc.ly/docs/api-reference-docs/configuration/theming/)
+- OpenAPI v3.0 support
+- Basic OpenAPI v3.1 support
+- Broad OpenAPI v2.0 feature support (yes, it supports even `discriminator`) <br>
+  ![](docs/images/discriminator-demo.gif)
+- Neat **interactive** documentation for nested objects <br>
+  ![](docs/images/nested-demo.gif)
+- Code samples support (via vendor extension) <br>
+  ![](docs/images/code-samples-demo.gif)
 
 ## Releases
-**Important:** all the 2.x releases are deployed to npm and can be used via jsdeliver:
-- particular release, e.g. `v2.0.0-alpha.15`: https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js
+**Important:** all the 2.x releases are deployed to npm and can be used with jsdeliver:
+- particular release, for example, `v2.0.0-alpha.15`: https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js
 - `next` release: https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js
 
 Additionally, all the 1.x releases are hosted on our GitHub Pages-based CDN **(deprecated)**:
@@ -64,153 +57,34 @@ Additionally, all the 1.x releases are hosted on our GitHub Pages-based CDN **(d
 | 1.18.x        | 2.0                   |
 | 1.17.x        | 2.0                   |
 
-## Some Real-life usages
+## Showcase
 - [Rebilly](https://api-reference.rebilly.com/)
 - [Docker Engine](https://docs.docker.com/engine/api/v1.25/)
 - [Zuora](https://www.zuora.com/developer/api-reference/)
 - [Discourse](http://docs.discourse.org)
 - [Commbox](https://www.commbox.io/api/)
 - [APIs.guru](https://apis.guru/api-doc/)
-- [FastAPI](https://github.com/tiangolo/fastapi)
 - [BoxKnight](https://www.docs.boxknight.com/)
 
 ## Deployment
-
-### TL;DR
-
-```html
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>ReDoc</title>
-    <!-- needed for adaptive design -->
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-
-    <!--
-    ReDoc doesn't change outer page styles
-    -->
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-      }
-    </style>
-  </head>
-  <body>
-    <redoc spec-url='http://petstore.swagger.io/v2/swagger.json'></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
-  </body>
-</html>
-```
-That's all folks!
-
-**IMPORTANT NOTE:** if you work with untrusted user spec, use `untrusted-spec` [option](#redoc-options-object) to prevent XSS security risks.
-
-### 1. Install ReDoc (skip this step for CDN)
-Install using [npm](https://docs.npmjs.com/getting-started/what-is-npm):
-
-    npm i redoc
-
-or using [yarn](https://yarnpkg.com):
-
-    yarn add redoc
-
-### 2. Reference redoc script in HTML
-For **CDN**:
-```html
-<script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"> </script>
-```
-
-For npm:
-```html
-<script src="node_modules/redoc/bundles/redoc.standalone.js"> </script>
-```
-
-### 3. Add `<redoc>` element to your page
-```html
-<redoc spec-url="url/to/your/spec"></redoc>
-```
-
-### 4. Enjoy :smile:
-
-
-## Usage as a React component
-
-Install peer dependencies required by ReDoc if you don't have them installed already:
-
-    npm i react react-dom mobx styled-components core-js
-
-Import `RedocStandalone` component from 'redoc' module:
-
-```js
-import { RedocStandalone } from 'redoc';
-```
-
-and use it somewhere in your component:
-
-```js
-<RedocStandalone specUrl="url/to/your/spec"/>
-```
-
-or
-
-```js
-<RedocStandalone spec={/* spec as an object */}/>
-```
-
-Also you can pass options:
-
-```js
-<RedocStandalone
-  specUrl="https://api.redoc.ly/registry/rebilly/core-api/core/bundle/master/openapi.yaml"
-  options={{
-    nativeScrollbars: true,
-    theme: { colors: { primary: { main: '#dd5522' } } },
-  }}
-/>
-```
-
-Here are detailed [options docs](#redoc-options-object).
-
-You can also specify `onLoaded` callback which will be called each time Redoc has been fully rendered or when error occurs (with an error as the first argument). *NOTE*: It may be called multiply times if you change component properties
-
-```js
-<RedocStandalone
-  specUrl="https://api.redoc.ly/registry/rebilly/core-api/core/bundle/master/openapi.yaml"
-  onLoaded={error => {
-    if (!error) {
-      console.log('Yay!');
-    }
-  }}
-/>
-```
+For step-by-step instructions for how to get started using Redoc
+to render your OpenAPI definition, refer to the 
+[Redoc quickstart guide](https://redoc.ly/docs/redoc/quickstart/intro/).
 
 [**IE11 Support Notes**](docs/usage-with-ie11.md)
 
-## The Docker way
-
-ReDoc is available as pre-built Docker image in official [Docker Hub repository](https://hub.docker.com/r/redocly/redoc/). You may simply pull & run it:
-
-    docker pull redocly/redoc
-    docker run -p 8080:80 redocly/redoc
-
-Also you may rewrite some predefined environment variables defined in [Dockerfile](./config/docker/Dockerfile). By default ReDoc starts with demo Petstore spec located at `http://petstore.swagger.io/v2/swagger.json`, but you may change this URL using environment variable `SPEC_URL`:
-
-    docker run -p 8080:80 -e SPEC_URL=https://api.example.com/openapi.json redocly/redoc
-
 ## ReDoc CLI
-
-[See here](https://github.com/Redocly/redoc/blob/master/cli/README.md)
+For more information on Redoc's commmand-line interface, refer to
+[Using the Redoc CLI](https://redoc.ly/docs/redoc/quickstart/cli/).
 
 ## Configuration
 
 ### Security Definition location
-You can inject Security Definitions widget into any place of your specification `description`. Check out details [here](docs/security-definitions-injection.md).
+You can inject the Security Definitions widget into any place in your definition `description`.
+For more information, refer to [Security definitions injection](docs/security-definitions-injection.md).
 
 ### Swagger vendor extensions
-ReDoc makes use of the following [vendor extensions](https://swagger.io/specification/#specificationExtensions):
+Redoc uses the following [vendor extensions](https://swagger.io/specification/#specificationExtensions):
 * [`x-logo`](docs/redoc-vendor-extensions.md#x-logo) - is used to specify API logo
 * [`x-traitTag`](docs/redoc-vendor-extensions.md#x-traitTag) - useful for handling out common things like Pagination, Rate-Limits, etc
 * [`x-codeSamples`](docs/redoc-vendor-extensions.md#x-codeSamples) - specify operation code samples
@@ -226,7 +100,7 @@ ReDoc makes use of the following [vendor extensions](https://swagger.io/specific
 * [`x-explicitMappingOnly`](docs/redoc-vendor-extensions.md#x-explicitMappingOnly) - In Schemas, display a more descriptive property name in objects with additionalProperties when viewing the property list with an object
 
 ### `<redoc>` options object
-You can use all of the following options with standalone version on <redoc> tag by kebab-casing them, e.g. `scrollYOffset` becomes `scroll-y-offset` and `expandResponses` becomes `expand-responses`.
+You can use all of the following options with the standalone version of the <redoc> tag by kebab-casing them. For example, `scrollYOffset` becomes `scroll-y-offset`, and `expandResponses` becomes `expand-responses`.
 
 * `disableSearch` - disable search indexing and search box.
 * `expandDefaultServerVariables` - enable expanding default server variables, default `false`.
@@ -315,23 +189,6 @@ You can use all of the following options with standalone version on <redoc> tag 
   * `backgroundColor`: '#263238'
   * `width`: '40%'
   * `textColor`: '#ffffff'
-
-## Advanced usage of standalone version
-Instead of adding `spec-url` attribute to the `<redoc>` element you can initialize ReDoc via globally exposed `Redoc` object:
-```js
-Redoc.init(specOrSpecUrl, options, element, callback?)
-```
-
-- `specOrSpecUrl` is either JSON object with specification or an URL to the spec in `JSON` or `YAML` format
-- `options` [options object](#redoc-options-object)
-- `element` DOM element to put ReDoc into
-- `callback` (optional) - callback to be called after Redoc has been fully rendered. It is also called on errors with error as the first argument
-
-```js
-Redoc.init('http://petstore.swagger.io/v2/swagger.json', {
-  scrollYOffset: 50
-}, document.getElementById('redoc-container'))
-```
 
 -----------
 ## Development


### PR DESCRIPTION
## What/Why/How?
Since my updates to the Redoc documentation have been published, I thought it would be a good idea to start updating the README file. One of the main ways I updated it was by removing the content that is now documented and including a link instead. I also did some other minor cleanup. I plan to do more work on the README in another PR.
## Reference
I have a task on my GitHub project board. https://github.com/HCloward/redoc/projects/1#card-67733561
## Testing
n/a
## Screenshots (optional)
n/a
## Check yourself
n/a
- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
