### PR TITLE
fix: The number of items in the array in the array is incorrect #1762

### DIFF
--- a/src/components/Schema/ArraySchema.tsx
+++ b/src/components/Schema/ArraySchema.tsx
@@ -13,15 +13,10 @@ const PaddedSchema = styled.div`
 
 export class ArraySchema extends React.PureComponent<SchemaProps> {
   render() {
-    const itemsSchema = this.props.schema.items!;
+    const itemsSchema = this.props.schema.items;
     const schema = this.props.schema;
 
-    const itemConstraintSchema = (
-      min: number | undefined = undefined,
-      max: number | undefined = undefined,
-    ) => ({ type: 'array', minItems: min, maxItems: max });
-
-    const minMaxItems = humanizeConstraints(itemConstraintSchema(itemsSchema?.schema?.minItems, itemsSchema?.schema?.maxItems));
+    const minMaxItems = humanizeConstraints(schema);
 
     if (schema.displayType && !itemsSchema && !minMaxItems.length) {
       return (<div>

--- a/src/services/models/Schema.ts
+++ b/src/services/models/Schema.ts
@@ -63,6 +63,8 @@ export class SchemaModel {
   const: any;
   contentEncoding?: string;
   contentMediaType?: string;
+  minItems?: number;
+  maxItems?: number;
 
   /**
    * @param isChild if schema discriminator Child
@@ -128,6 +130,8 @@ export class SchemaModel {
     this.const = schema.const || '';
     this.contentEncoding = schema.contentEncoding;
     this.contentMediaType = schema.contentMediaType;
+    this.minItems = schema.minItems;
+    this.maxItems = schema.maxItems;
 
     if (!!schema.nullable || schema['x-nullable']) {
       if (Array.isArray(this.type) && !this.type.some((value) => value === null || value === 'null')) {


### PR DESCRIPTION
## What/Why/How?
closes https://github.com/Redocly/redoc/issues/1762
## Reference
the problem came from here https://github.com/Redocly/redoc/pull/1308 (description is here https://github.com/Redocly/redoc/issues/1131)

`minItems` and `maxItems` should be at the same level as `type: 'array'`, not at the `items` level

## Screenshots (optional)
<img width="337" alt="Screenshot 2021-10-05 at 18 30 23" src="https://user-images.githubusercontent.com/16255408/136054521-1244b5d1-1bf4-45fb-b853-621646d3d818.png">

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
