### PR TITLE
fix: fix scroll in example dropdown

### DIFF
--- a/src/components/Operation/Operation.tsx
+++ b/src/components/Operation/Operation.tsx
@@ -18,11 +18,6 @@ import { ResponsesList } from '../Responses/ResponsesList';
 import { ResponseSamples } from '../ResponseSamples/ResponseSamples';
 import { SecurityRequirements } from '../SecurityRequirement/SecurityRequirement';
 
-const OperationRow = styled(Row)`
-  backface-visibility: hidden;
-  contain: content;
-  overflow: hidden;
-`;
 
 const Description = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing.unit * 6}px;
@@ -43,7 +38,7 @@ export class Operation extends React.Component<OperationProps> {
     return (
       <OptionsContext.Consumer>
         {options => (
-          <OperationRow>
+          <Row>
             <MiddlePanel>
               <H2>
                 <ShareLink to={operation.id} />
@@ -71,7 +66,7 @@ export class Operation extends React.Component<OperationProps> {
               <ResponseSamples operation={operation} />
               <CallbackSamples callbacks={operation.callbacks} />
             </DarkRightPanel>
-          </OperationRow>
+          </Row>
         )}
       </OptionsContext.Consumer>
     );


### PR DESCRIPTION
## What/Why/How?
fixed https://github.com/Redocly/redoc/issues/1756

## Reference

## Testing

## Screenshots (optional)
### Before:
<img width="380" alt="Screenshot 2021-11-24 at 17 03 26" src="https://user-images.githubusercontent.com/14113673/143262662-d8bda8f5-3060-42b3-a4fe-5c30e6171e87.png">

### After:
<img width="380" alt="Screenshot 2021-11-24 at 17 02 56" src="https://user-images.githubusercontent.com/14113673/143262646-7f23af71-e51b-4533-89a6-88d5fa09a7df.png">


## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
