### PR TITLE
Use an option usePathInSidebar

### DIFF
--- a/src/components/SideMenu/MenuItem.tsx
+++ b/src/components/SideMenu/MenuItem.tsx
@@ -45,8 +45,8 @@ export class MenuItem extends React.Component<MenuItemProps> {
           <OperationMenuItemContent {...this.props} item={item as OperationModel} />
         ) : (
           <MenuItemLabel depth={item.depth} active={item.active} type={item.type} ref={this.ref}>
-            <MenuItemTitle title={item.sidebarName}>
-              {item.sidebarName}
+            <MenuItemTitle title={item.sidebarLabel}>
+              {item.sidebarLabel}
               {this.props.children}
             </MenuItemTitle>
             {(item.depth > 0 && item.items.length > 0 && (
@@ -96,7 +96,7 @@ export class OperationMenuItemContent extends React.Component<OperationMenuItemC
           <OperationBadge type={item.httpVerb}>{shortenHTTPVerb(item.httpVerb)}</OperationBadge>
         )}
         <MenuItemTitle width="calc(100% - 38px)">
-          {item.sidebarName}
+          {item.sidebarLabel}
           {this.props.children}
         </MenuItemTitle>
       </MenuItemLabel>

--- a/src/components/SideMenu/MenuItem.tsx
+++ b/src/components/SideMenu/MenuItem.tsx
@@ -45,8 +45,8 @@ export class MenuItem extends React.Component<MenuItemProps> {
           <OperationMenuItemContent {...this.props} item={item as OperationModel} />
         ) : (
           <MenuItemLabel depth={item.depth} active={item.active} type={item.type} ref={this.ref}>
-            <MenuItemTitle title={item.name}>
-              {item.name}
+            <MenuItemTitle title={item.sidebarName}>
+              {item.sidebarName}
               {this.props.children}
             </MenuItemTitle>
             {(item.depth > 0 && item.items.length > 0 && (
@@ -96,7 +96,7 @@ export class OperationMenuItemContent extends React.Component<OperationMenuItemC
           <OperationBadge type={item.httpVerb}>{shortenHTTPVerb(item.httpVerb)}</OperationBadge>
         )}
         <MenuItemTitle width="calc(100% - 38px)">
-          {item.name}
+          {item.sidebarName}
           {this.props.children}
         </MenuItemTitle>
       </MenuItemLabel>

--- a/src/services/MenuStore.ts
+++ b/src/services/MenuStore.ts
@@ -16,7 +16,7 @@ export interface IMenuItem {
   id: string;
   absoluteIdx?: number;
   name: string;
-  sidebarName: string;
+  sidebarLabel: string;
   description?: string;
   depth: number;
   active: boolean;

--- a/src/services/MenuStore.ts
+++ b/src/services/MenuStore.ts
@@ -16,6 +16,7 @@ export interface IMenuItem {
   id: string;
   absoluteIdx?: number;
   name: string;
+  sidebarName: string;
   description?: string;
   depth: number;
   active: boolean;

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -22,7 +22,7 @@ export interface RedocRawOptions {
   disableSearch?: boolean | string;
   onlyRequiredInSamples?: boolean | string;
   showExtensions?: boolean | string | string[];
-  usePathInSidebar?: boolean;
+  sideNavStyle?: string | 'summary-only';
   hideSingleRequestSampleTab?: boolean | string;
   menuToggle?: boolean | string;
   jsonSampleExpandLevel?: number | string | 'all';
@@ -143,6 +143,22 @@ export class RedocNormalizedOptions {
     }
   }
 
+  static normalizeSideNavStyle(value: RedocRawOptions['sideNavStyle']): string {
+    const defaultValue = 'summary-only';
+    if (typeof value !== 'string') {
+      return defaultValue;
+    }
+
+    switch (value) {
+      case defaultValue:
+        return value;
+      case 'path-only':
+        return value;
+      default:
+        return defaultValue;
+    }
+  }
+
   static normalizePayloadSampleIdx(value: RedocRawOptions['payloadSampleIdx']): number {
     if (typeof value === 'number') {
       return Math.max(0, value); // always greater or equal than 0
@@ -190,7 +206,7 @@ export class RedocNormalizedOptions {
   disableSearch: boolean;
   onlyRequiredInSamples: boolean;
   showExtensions: boolean | string[];
-  usePathInSidebar: boolean;
+  sideNavStyle: string;
   hideSingleRequestSampleTab: boolean;
   menuToggle: boolean;
   jsonSampleExpandLevel: number;
@@ -249,7 +265,7 @@ export class RedocNormalizedOptions {
     this.disableSearch = argValueToBoolean(raw.disableSearch);
     this.onlyRequiredInSamples = argValueToBoolean(raw.onlyRequiredInSamples);
     this.showExtensions = RedocNormalizedOptions.normalizeShowExtensions(raw.showExtensions);
-    this.usePathInSidebar = argValueToBoolean(raw.usePathInSidebar);
+    this.sideNavStyle = RedocNormalizedOptions.normalizeSideNavStyle(raw.sideNavStyle);
     this.hideSingleRequestSampleTab = argValueToBoolean(raw.hideSingleRequestSampleTab);
     this.menuToggle = argValueToBoolean(raw.menuToggle, true);
     this.jsonSampleExpandLevel = RedocNormalizedOptions.normalizeJsonSampleExpandLevel(

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -5,6 +5,11 @@ import { isNumeric, mergeObjects } from '../utils/helpers';
 import { LabelsConfigRaw, setRedocLabels } from './Labels';
 import { MDXComponentMeta } from './MarkdownRenderer';
 
+export enum SideNavStyleEnum {
+  SummaryOnly = 'summary-only',
+  PathOnly = 'path-only',
+}
+
 export interface RedocRawOptions {
   theme?: ThemeInterface;
   scrollYOffset?: number | string | (() => number);
@@ -22,7 +27,7 @@ export interface RedocRawOptions {
   disableSearch?: boolean | string;
   onlyRequiredInSamples?: boolean | string;
   showExtensions?: boolean | string | string[];
-  sideNavStyle?: string | 'summary-only';
+  sideNavStyle?: SideNavStyleEnum;
   hideSingleRequestSampleTab?: boolean | string;
   menuToggle?: boolean | string;
   jsonSampleExpandLevel?: number | string | 'all';
@@ -143,8 +148,8 @@ export class RedocNormalizedOptions {
     }
   }
 
-  static normalizeSideNavStyle(value: RedocRawOptions['sideNavStyle']): string {
-    const defaultValue = 'summary-only';
+  static normalizeSideNavStyle(value: RedocRawOptions['sideNavStyle']): SideNavStyleEnum {
+    const defaultValue = SideNavStyleEnum.SummaryOnly;
     if (typeof value !== 'string') {
       return defaultValue;
     }
@@ -152,8 +157,8 @@ export class RedocNormalizedOptions {
     switch (value) {
       case defaultValue:
         return value;
-      case 'path-only':
-        return value;
+      case SideNavStyleEnum.PathOnly:
+        return SideNavStyleEnum.PathOnly;
       default:
         return defaultValue;
     }
@@ -206,7 +211,7 @@ export class RedocNormalizedOptions {
   disableSearch: boolean;
   onlyRequiredInSamples: boolean;
   showExtensions: boolean | string[];
-  sideNavStyle: string;
+  sideNavStyle: SideNavStyleEnum;
   hideSingleRequestSampleTab: boolean;
   menuToggle: boolean;
   jsonSampleExpandLevel: number;

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -22,6 +22,7 @@ export interface RedocRawOptions {
   disableSearch?: boolean | string;
   onlyRequiredInSamples?: boolean | string;
   showExtensions?: boolean | string | string[];
+  usePathInSidebar?: boolean;
   hideSingleRequestSampleTab?: boolean | string;
   menuToggle?: boolean | string;
   jsonSampleExpandLevel?: number | string | 'all';
@@ -189,6 +190,7 @@ export class RedocNormalizedOptions {
   disableSearch: boolean;
   onlyRequiredInSamples: boolean;
   showExtensions: boolean | string[];
+  usePathInSidebar: boolean;
   hideSingleRequestSampleTab: boolean;
   menuToggle: boolean;
   jsonSampleExpandLevel: number;
@@ -247,6 +249,7 @@ export class RedocNormalizedOptions {
     this.disableSearch = argValueToBoolean(raw.disableSearch);
     this.onlyRequiredInSamples = argValueToBoolean(raw.onlyRequiredInSamples);
     this.showExtensions = RedocNormalizedOptions.normalizeShowExtensions(raw.showExtensions);
+    this.usePathInSidebar = argValueToBoolean(raw.usePathInSidebar);
     this.hideSingleRequestSampleTab = argValueToBoolean(raw.hideSingleRequestSampleTab);
     this.menuToggle = argValueToBoolean(raw.menuToggle, true);
     this.jsonSampleExpandLevel = RedocNormalizedOptions.normalizeJsonSampleExpandLevel(

--- a/src/services/models/Group.model.ts
+++ b/src/services/models/Group.model.ts
@@ -14,7 +14,7 @@ export class GroupModel implements IMenuItem {
   id: string;
   absoluteIdx?: number;
   name: string;
-  sidebarName: string;
+  sidebarLabel: string;
   description?: string;
   type: MenuItemGroupType;
 
@@ -44,7 +44,7 @@ export class GroupModel implements IMenuItem {
     this.name = tagOrGroup['x-displayName'] || tagOrGroup.name;
     this.level = (tagOrGroup as MarkdownHeading).level || 1;
 
-    this.sidebarName = this.name;
+    this.sidebarLabel = this.name;
 
     // remove sections from markdown, same as in ApiInfo
     this.description = tagOrGroup.description || '';

--- a/src/services/models/Group.model.ts
+++ b/src/services/models/Group.model.ts
@@ -14,6 +14,7 @@ export class GroupModel implements IMenuItem {
   id: string;
   absoluteIdx?: number;
   name: string;
+  sidebarName: string;
   description?: string;
   type: MenuItemGroupType;
 
@@ -42,6 +43,8 @@ export class GroupModel implements IMenuItem {
     this.type = type;
     this.name = tagOrGroup['x-displayName'] || tagOrGroup.name;
     this.level = (tagOrGroup as MarkdownHeading).level || 1;
+
+    this.sidebarName = this.name;
 
     // remove sections from markdown, same as in ApiInfo
     this.description = tagOrGroup.description || '';

--- a/src/services/models/Operation.ts
+++ b/src/services/models/Operation.ts
@@ -106,7 +106,7 @@ export class OperationModel implements IMenuItem {
     this.name = getOperationSummary(operationSpec);
 
     this.sidebarName = this.name;
-    if (options.usePathInSidebar) this.sidebarName = this.path;
+    if (options.sideNavStyle === 'path-only') this.sidebarName = this.path;
 
     if (this.isCallback) {
       // NOTE: Callbacks by default should not inherit the specification's global `security` definition.

--- a/src/services/models/Operation.ts
+++ b/src/services/models/Operation.ts
@@ -49,6 +49,7 @@ export class OperationModel implements IMenuItem {
   id: string;
   absoluteIdx?: number;
   name: string;
+  sidebarName: string;
   description?: string;
   type = 'operation' as const;
 
@@ -103,6 +104,9 @@ export class OperationModel implements IMenuItem {
     this.isEvent = this.isCallback || this.isWebhook;
 
     this.name = getOperationSummary(operationSpec);
+
+    this.sidebarName = this.name;
+    if (options.usePathInSidebar) this.sidebarName = this.path;
 
     if (this.isCallback) {
       // NOTE: Callbacks by default should not inherit the specification's global `security` definition.

--- a/src/services/models/Operation.ts
+++ b/src/services/models/Operation.ts
@@ -25,6 +25,7 @@ import { FieldModel } from './Field';
 import { MediaContentModel } from './MediaContent';
 import { RequestBodyModel } from './RequestBody';
 import { ResponseModel } from './Response';
+import { SideNavStyleEnum } from '../RedocNormalizedOptions';
 
 export interface XPayloadSample {
   lang: 'payload';
@@ -105,7 +106,7 @@ export class OperationModel implements IMenuItem {
 
     this.name = getOperationSummary(operationSpec);
 
-    this.sidebarLabel = options.sideNavStyle === 'path-only' ? this.path : this.name;
+    this.sidebarLabel = options.sideNavStyle === SideNavStyleEnum.PathOnly ? this.path : this.name;
 
     if (this.isCallback) {
       // NOTE: Callbacks by default should not inherit the specification's global `security` definition.

--- a/src/services/models/Operation.ts
+++ b/src/services/models/Operation.ts
@@ -49,7 +49,7 @@ export class OperationModel implements IMenuItem {
   id: string;
   absoluteIdx?: number;
   name: string;
-  sidebarName: string;
+  sidebarLabel: string;
   description?: string;
   type = 'operation' as const;
 
@@ -105,8 +105,8 @@ export class OperationModel implements IMenuItem {
 
     this.name = getOperationSummary(operationSpec);
 
-    this.sidebarName = this.name;
-    if (options.sideNavStyle === 'path-only') this.sidebarName = this.path;
+    this.sidebarLabel = this.name;
+    if (options.sideNavStyle === 'path-only') this.sidebarLabel = this.path;
 
     if (this.isCallback) {
       // NOTE: Callbacks by default should not inherit the specification's global `security` definition.

--- a/src/services/models/Operation.ts
+++ b/src/services/models/Operation.ts
@@ -105,8 +105,7 @@ export class OperationModel implements IMenuItem {
 
     this.name = getOperationSummary(operationSpec);
 
-    this.sidebarLabel = this.name;
-    if (options.sideNavStyle === 'path-only') this.sidebarLabel = this.path;
+    this.sidebarLabel = options.sideNavStyle === 'path-only' ? this.path : this.name;
 
     if (this.isCallback) {
       // NOTE: Callbacks by default should not inherit the specification's global `security` definition.


### PR DESCRIPTION
## What/Why/How?
We found an requirement that we want the path to be shown in the sidebar.
If this option is enabled, it displays a path in the sidebar instead of summary.

Usage:

```js
                <RedocStandalone
                spec={props.spec}
                options={{
                    scrollYOffset:'.navbar',
                    nativeScrollbars: true,
                    sideNavStyle: 'summary-only' or 'path-only'
                }}
```

## Reference

## Testing

## Screenshots (optional)
sideNavStyle == 'summary-only'
![image](https://user-images.githubusercontent.com/20692739/143569494-6b0eb207-7db8-4d76-acd4-c8ff70328f1e.png)

sideNavStyle == 'path-only'
![image](https://user-images.githubusercontent.com/20692739/143569527-210701c4-5071-4621-9920-3f95e048ba5d.png)


## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
