### PR TITLE
fix: Overrides user-provided discriminator values with object names (…

### DIFF
--- a/src/components/Schema/DiscriminatorDropdown.tsx
+++ b/src/components/Schema/DiscriminatorDropdown.tsx
@@ -33,7 +33,7 @@ export class DiscriminatorDropdown extends React.Component<{
 
     const options = parent.oneOf.map((subSchema, idx) => {
       return {
-        value: subSchema.title,
+        value: subSchema.discriminant(parent.discriminatorProp),
         idx,
       };
     });

--- a/src/services/models/MediaType.ts
+++ b/src/services/models/MediaType.ts
@@ -63,10 +63,11 @@ export class MediaTypeModel {
         const sample = Sampler.sample(subSchema.rawSchema as any, samplerOptions, parser.spec);
 
         if (this.schema.discriminatorProp && typeof sample === 'object' && sample) {
-          sample[this.schema.discriminatorProp] = subSchema.title;
+          sample[this.schema.discriminatorProp] = subSchema.discriminant(
+            this.schema.discriminatorProp,
+          );
         }
-
-        this.examples[subSchema.title] = new ExampleModel(
+        this.examples[subSchema.discriminant()] = new ExampleModel(
           parser,
           {
             value: sample,

--- a/src/services/models/Schema.ts
+++ b/src/services/models/Schema.ts
@@ -102,6 +102,26 @@ export class SchemaModel {
     this.activeOneOf = idx;
   }
 
+  discriminant(propName?): string {
+    if (!propName) {
+      propName = this.schema.discriminator?.propertyName;
+    }
+
+    if (!propName) {
+      return this.title;
+    }
+
+    const properties = this.schema.properties;
+
+    if (!properties) {
+      return this.title;
+    }
+
+    const prop = properties[propName] || null;
+
+    return (prop && prop.enum && prop.enum.length && prop.enum[0]) || this.title;
+  }
+
   hasType(type: string) {
     return this.type === type || (Array.isArray(this.type) && this.type.includes(type));
   }


### PR DESCRIPTION
…#1794)

## What/Why/How?

Fixes "Overrides user-provided discriminator values with object names"

## Reference

[issue 1794](https://github.com/Redocly/redoc/issues/1794)
[vehicles.yaml.txt](https://github.com/Redocly/redoc/files/7656573/vehicles.yaml.txt)

## Testing

Sorry, no new tests, though there should be.  But existing tests still pass.

## Screenshots (optional)

## Check yourself

This pull request is more advisory/informational than a full pull request.  I did not write tests for the new functionality.

- [✔] Code is linted
- [✔] Tested
- [ x] All new/updated code is covered with tests
