### PR TITLE
Fix Chrome scrolling by using alternate scrollIntoViewIfNeeded

### DIFF
--- a/src/components/SideMenu/MenuItem.tsx
+++ b/src/components/SideMenu/MenuItem.tsx
@@ -7,6 +7,7 @@ import { shortenHTTPVerb } from '../../utils/openapi';
 import { MenuItems } from './MenuItems';
 import { MenuItemLabel, MenuItemLi, MenuItemTitle, OperationBadge } from './styled.elements';
 import { l } from '../../services/Labels';
+import { scrollIntoViewIfNeeded } from '../../utils';
 
 export interface MenuItemProps {
   item: IMenuItem;
@@ -33,7 +34,7 @@ export class MenuItem extends React.Component<MenuItemProps> {
 
   scrollIntoViewIfActive() {
     if (this.props.item.active && this.ref.current) {
-      this.ref.current.scrollIntoViewIfNeeded();
+      scrollIntoViewIfNeeded(this.ref.current);
     }
   }
 
@@ -77,7 +78,7 @@ export class OperationMenuItemContent extends React.Component<OperationMenuItemC
 
   componentDidUpdate() {
     if (this.props.item.active && this.ref.current) {
-      this.ref.current.scrollIntoViewIfNeeded();
+      scrollIntoViewIfNeeded(this.ref.current);
     }
   }
 

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -37,7 +37,6 @@ export class SideMenu extends React.Component<{ menu: MenuStore; className?: str
     if (item && item.active && this.context.menuToggle) {
       return item.expanded ? item.collapse() : item.expand();
     }
-
     this.props.menu.activateAndScroll(item, true);
     setTimeout(() => {
       if (this._updateScroll) {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -26,50 +26,55 @@ export function html2Str(html: string): string {
 
 // scrollIntoViewIfNeeded polyfill
 
+export function scrollIntoViewIfNeeded(el: HTMLElement, centerIfNeeded = true) {
+  const parent = el.parentNode as HTMLElement | null;
+  if (!parent) {
+    return;
+  }
+  const parentComputedStyle = window.getComputedStyle(parent, undefined);
+  const parentBorderTopWidth = parseInt(
+    parentComputedStyle.getPropertyValue('border-top-width'),
+    10,
+  );
+  const parentBorderLeftWidth = parseInt(
+    parentComputedStyle.getPropertyValue('border-left-width'),
+    10,
+  );
+  const overTop = el.offsetTop - parent.offsetTop < parent.scrollTop;
+  const overBottom =
+    el.offsetTop - parent.offsetTop + el.clientHeight - parentBorderTopWidth >
+    parent.scrollTop + parent.clientHeight;
+  const overLeft = el.offsetLeft - parent.offsetLeft < parent.scrollLeft;
+  const overRight =
+    el.offsetLeft - parent.offsetLeft + el.clientWidth - parentBorderLeftWidth >
+    parent.scrollLeft + parent.clientWidth;
+  const alignWithTop = overTop && !overBottom;
+
+  if ((overTop || overBottom) && centerIfNeeded) {
+    parent.scrollTop =
+      el.offsetTop -
+      parent.offsetTop -
+      parent.clientHeight / 2 -
+      parentBorderTopWidth +
+      el.clientHeight / 2;
+  }
+
+  if ((overLeft || overRight) && centerIfNeeded) {
+    parent.scrollLeft =
+      el.offsetLeft -
+      parent.offsetLeft -
+      parent.clientWidth / 2 -
+      parentBorderLeftWidth +
+      el.clientWidth / 2;
+  }
+
+  if ((overTop || overBottom || overLeft || overRight) && !centerIfNeeded) {
+    el.scrollIntoView(alignWithTop);
+  }
+}
+
 if (typeof Element !== 'undefined' && !(Element as any).prototype.scrollIntoViewIfNeeded) {
-  (Element as any).prototype.scrollIntoViewIfNeeded = function (centerIfNeeded) {
-    centerIfNeeded = arguments.length === 0 ? true : !!centerIfNeeded;
-
-    const parent = this.parentNode;
-    const parentComputedStyle = window.getComputedStyle(parent, undefined);
-    const parentBorderTopWidth = parseInt(
-      parentComputedStyle.getPropertyValue('border-top-width'),
-      10,
-    );
-    const parentBorderLeftWidth = parseInt(
-      parentComputedStyle.getPropertyValue('border-left-width'),
-      10,
-    );
-    const overTop = this.offsetTop - parent.offsetTop < parent.scrollTop;
-    const overBottom =
-      this.offsetTop - parent.offsetTop + this.clientHeight - parentBorderTopWidth >
-      parent.scrollTop + parent.clientHeight;
-    const overLeft = this.offsetLeft - parent.offsetLeft < parent.scrollLeft;
-    const overRight =
-      this.offsetLeft - parent.offsetLeft + this.clientWidth - parentBorderLeftWidth >
-      parent.scrollLeft + parent.clientWidth;
-    const alignWithTop = overTop && !overBottom;
-
-    if ((overTop || overBottom) && centerIfNeeded) {
-      parent.scrollTop =
-        this.offsetTop -
-        parent.offsetTop -
-        parent.clientHeight / 2 -
-        parentBorderTopWidth +
-        this.clientHeight / 2;
-    }
-
-    if ((overLeft || overRight) && centerIfNeeded) {
-      parent.scrollLeft =
-        this.offsetLeft -
-        parent.offsetLeft -
-        parent.clientWidth / 2 -
-        parentBorderLeftWidth +
-        this.clientWidth / 2;
-    }
-
-    if ((overTop || overBottom || overLeft || overRight) && !centerIfNeeded) {
-      this.scrollIntoView(alignWithTop);
-    }
+  (Element as any).prototype.scrollIntoViewIfNeeded = function (centerIfNeeded = true) {
+    scrollIntoViewIfNeeded(this, centerIfNeeded);
   };
 }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -24,7 +24,10 @@ export function html2Str(html: string): string {
     .join(' ');
 }
 
-// scrollIntoViewIfNeeded polyfill
+// Alternate scrollIntoViewIfNeeded implementation.
+// Used in all cases, since it seems Chrome's implementation is buggy
+// when "Experimental Web Platform Features" is enabled (at least of version 96).
+// See #1714, #1742
 
 export function scrollIntoViewIfNeeded(el: HTMLElement, centerIfNeeded = true) {
   const parent = el.parentNode as HTMLElement | null;
@@ -71,10 +74,4 @@ export function scrollIntoViewIfNeeded(el: HTMLElement, centerIfNeeded = true) {
   if ((overTop || overBottom || overLeft || overRight) && !centerIfNeeded) {
     el.scrollIntoView(alignWithTop);
   }
-}
-
-if (typeof Element !== 'undefined' && !(Element as any).prototype.scrollIntoViewIfNeeded) {
-  (Element as any).prototype.scrollIntoViewIfNeeded = function (centerIfNeeded = true) {
-    scrollIntoViewIfNeeded(this, centerIfNeeded);
-  };
 }


### PR DESCRIPTION
## What/Why/How?

Scrolling the documentation on Chrome seems to be broken in certain configurations (e.g. when Experimental Web Platform Features is enabled).

This seems to be caused by a faulty `scrollIntoViewIfNeeded` implementation (https://github.com/Redocly/redoc/issues/1714#issuecomment-897420205).

There already is a polyfill/implementation for the function in the codebase that works correctly in Chrome, so this changes things to always use that implementation instead of the possibly buggy native one.

## Reference

Fixes #1714

Refs #1742 (can't say it outright fixes it, didn't test on mobile)

## Testing

Seems to work on my Chrome!

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
  - by hand 
- [x] All new/updated code is covered with tests
  - no new code, no new tests
