### PR TITLE
fix: attachHeadingsDescriptions match headings incorrectly

### DIFF
--- a/src/services/MarkdownRenderer.ts
+++ b/src/services/MarkdownRenderer.ts
@@ -101,7 +101,7 @@ export class MarkdownRenderer {
 
   attachHeadingsDescriptions(rawText: string) {
     const buildRegexp = (heading: MarkdownHeading) => {
-      return new RegExp(`##?\\s+${heading.name.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')}`);
+      return new RegExp(`##?\\s+${heading.name.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')}\s*$`);
     };
 
     const flatHeadings = this.flattenHeadings(this.headings);


### PR DESCRIPTION
## What/Why/How?

if headings have same prefix, the description will mess up, see below:
```yaml
info:
  openapi: 3.1.0
  title: test
  version: v1
  description: |+
    # intro
    # modules
    ## user_module
    some text
   
    ## user
    some text2
```

then you can see:
![image](https://user-images.githubusercontent.com/8580744/147359585-a185b4b9-0855-4aa4-9103-411bd0378a22.png)

how to fix?
just match heading to end of the line.

## Reference

## Testing

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
