### PR TITLE
MenuBuilder: Add support for `sortOperationsAlphabetically` and `sortTagsAlphabetically `

### DIFF
--- a/src/services/MenuBuilder.ts
+++ b/src/services/MenuBuilder.ts
@@ -12,6 +12,7 @@ import {
   SECURITY_DEFINITIONS_COMPONENT_NAME,
   setSecuritySchemePrefix,
   JsonPointer,
+  alphabeticallyByProp,
 } from '../utils';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { GroupModel, OperationModel } from './models';
@@ -188,9 +189,11 @@ export class MenuBuilder {
 
   /**
    * Returns array of Operation items for the tag
+   * @param parser
    * @param parent parent OperationsGroup
    * @param tag tag info returned from `getTagsWithOperations`
    * @param depth items depth
+   * @param options - normalized options
    */
   static getOperationsItems(
     parser: OpenAPIParser,
@@ -209,9 +212,11 @@ export class MenuBuilder {
       operation.depth = depth;
       res.push(operation);
     }
+
     if (options.sortOperationsAlphabetically) {
-      res.sort((a, b) => a.name.localeCompare(b.name));
+      res.sort(alphabeticallyByProp<OperationModel>('name'));
     }
+
     return res;
   }
 

--- a/src/services/MenuBuilder.ts
+++ b/src/services/MenuBuilder.ts
@@ -209,6 +209,9 @@ export class MenuBuilder {
       operation.depth = depth;
       res.push(operation);
     }
+    if (options.sortOperationsAlphabetically) {
+      res.sort((a, b) => a.name.localeCompare(b.name));
+    }
     return res;
   }
 

--- a/src/services/MenuBuilder.ts
+++ b/src/services/MenuBuilder.ts
@@ -131,9 +131,11 @@ export class MenuBuilder {
 
   /**
    * Returns array of OperationsGroup items for the tags of the group or for all tags
+   * @param parser
    * @param tagsMap tags info returned from `getTagsWithOperations`
    * @param parent parent item
    * @param group group which this tag belongs to. if not provided gets all tags
+   * @param options normalized options
    */
   static getTagsItems(
     parser: OpenAPIParser,
@@ -184,6 +186,11 @@ export class MenuBuilder {
 
       res.push(item);
     }
+
+    if (options.sortTagsAlphabetically) {
+      res.sort(alphabeticallyByProp<GroupModel | OperationModel>('name'));
+    }
+
     return res;
   }
 

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -19,6 +19,7 @@ export interface RedocRawOptions {
   sortPropsAlphabetically?: boolean | string;
   sortEnumValuesAlphabetically?: boolean | string;
   sortOperationsAlphabetically?: boolean | string;
+  sortTagsAlphabetically?: boolean | string;
   noAutoAuth?: boolean | string;
   nativeScrollbars?: boolean | string;
   pathInMiddlePanel?: boolean | string;
@@ -205,6 +206,7 @@ export class RedocNormalizedOptions {
   sortPropsAlphabetically: boolean;
   sortEnumValuesAlphabetically: boolean;
   sortOperationsAlphabetically: boolean;
+  sortTagsAlphabetically: boolean;
   noAutoAuth: boolean;
   nativeScrollbars: boolean;
   pathInMiddlePanel: boolean;
@@ -265,6 +267,7 @@ export class RedocNormalizedOptions {
     this.sortPropsAlphabetically = argValueToBoolean(raw.sortPropsAlphabetically);
     this.sortEnumValuesAlphabetically = argValueToBoolean(raw.sortEnumValuesAlphabetically);
     this.sortOperationsAlphabetically = argValueToBoolean(raw.sortOperationsAlphabetically);
+    this.sortTagsAlphabetically = argValueToBoolean(raw.sortTagsAlphabetically);
     this.noAutoAuth = argValueToBoolean(raw.noAutoAuth);
     this.nativeScrollbars = argValueToBoolean(raw.nativeScrollbars);
     this.pathInMiddlePanel = argValueToBoolean(raw.pathInMiddlePanel);

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -18,6 +18,7 @@ export interface RedocRawOptions {
   requiredPropsFirst?: boolean | string;
   sortPropsAlphabetically?: boolean | string;
   sortEnumValuesAlphabetically?: boolean | string;
+  sortOperationsAlphabetically?: boolean | string;
   noAutoAuth?: boolean | string;
   nativeScrollbars?: boolean | string;
   pathInMiddlePanel?: boolean | string;
@@ -203,6 +204,7 @@ export class RedocNormalizedOptions {
   requiredPropsFirst: boolean;
   sortPropsAlphabetically: boolean;
   sortEnumValuesAlphabetically: boolean;
+  sortOperationsAlphabetically: boolean;
   noAutoAuth: boolean;
   nativeScrollbars: boolean;
   pathInMiddlePanel: boolean;
@@ -262,6 +264,7 @@ export class RedocNormalizedOptions {
     this.requiredPropsFirst = argValueToBoolean(raw.requiredPropsFirst);
     this.sortPropsAlphabetically = argValueToBoolean(raw.sortPropsAlphabetically);
     this.sortEnumValuesAlphabetically = argValueToBoolean(raw.sortEnumValuesAlphabetically);
+    this.sortOperationsAlphabetically = argValueToBoolean(raw.sortOperationsAlphabetically);
     this.noAutoAuth = argValueToBoolean(raw.noAutoAuth);
     this.nativeScrollbars = argValueToBoolean(raw.nativeScrollbars);
     this.pathInMiddlePanel = argValueToBoolean(raw.pathInMiddlePanel);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './dom';
 export * from './decorators';
 export * from './debug';
 export * from './memoize';
+export * from './sort';

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,0 +1,21 @@
+/**
+ * Function that returns a comparator for sorting objects by some specific key alphabetically.
+ *
+ * @param {String} property key of the object to sort, if starts from `-` - reverse
+ */
+export function alphabeticallyByProp<T>(property: string): (a: T, b: T) => number {
+  let sortOrder = 1;
+
+  if (property[0] === '-') {
+    sortOrder = -1;
+    property = property.substr(1);
+  }
+
+  return (a: T, b: T) => {
+    if (sortOrder == -1) {
+      return b[property].localeCompare(a[property]);
+    } else {
+      return a[property].localeCompare(b[property]);
+    }
+  };
+}


### PR DESCRIPTION
Already documented but is currently `NO-OP` and not implemented
`sortOperationsAlphabetically` and `sortTagsAlphabetically `.

Allows sorting operations in sidebar menu according to their `name`
configured which is by default `summary` from Swaggerspec

TLDR:
Following commit adds support for `sortOperationsAlphabetically` and `sortTagsAlphabetically ` already
documented but not implemented here: https://redoc.ly/docs/api-reference-docs/guides/migration-guide-2-0/#automated-sorting