### PR TITLE
fix: external ref in schema definition

### DIFF
--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -191,6 +191,11 @@ export class OpenAPIParser {
     const { $ref, ...rest } = ref;
     const keys = Object.keys(rest);
     if (keys.length === 0) {
+      if (this.isRef(resolved)) {
+        const result = this.deref(resolved, false, mergeAsAllOf);
+        this.exitRef(resolved);
+        return result;
+      }
       return resolved;
     }
     if (

--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -192,9 +192,7 @@ export class OpenAPIParser {
     const keys = Object.keys(rest);
     if (keys.length === 0) {
       if (this.isRef(resolved)) {
-        const result = this.deref(resolved, false, mergeAsAllOf);
-        this.exitRef(resolved);
-        return result;
+        return this.shallowDeref(resolved);
       }
       return resolved;
     }

--- a/src/services/__tests__/OpenAPIParser.test.ts
+++ b/src/services/__tests__/OpenAPIParser.test.ts
@@ -26,5 +26,16 @@ describe('Models', () => {
 
       expect(parser.shallowDeref(schemaOrRef)).toMatchSnapshot();
     });
+
+    test('should correct resolve double $ref if no need sibling', () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const spec = require('./fixtures/3.1/schemaDefinition.json');
+      parser = new OpenAPIParser(spec, undefined, opts);
+      const schemaOrRef: Referenced<OpenAPIParameter> = {
+        $ref: '#/components/schemas/Parent',
+      };
+
+      expect(parser.deref(schemaOrRef, false, true)).toMatchSnapshot();
+    });
   });
 });

--- a/src/services/__tests__/__snapshots__/OpenAPIParser.test.ts.snap
+++ b/src/services/__tests__/__snapshots__/OpenAPIParser.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Models Schema should correct resolve double $ref if no need sibling 1`] = `
+Object {
+  "properties": Object {
+    "test": Object {
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;
+
 exports[`Models Schema should hoist oneOfs when mergin allOf 1`] = `
 Object {
   "oneOf": Array [

--- a/src/services/__tests__/fixtures/3.1/schemaDefinition.json
+++ b/src/services/__tests__/fixtures/3.1/schemaDefinition.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Schema definition double $ref",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "example.com"
+    }
+  ],
+  "tags": [
+    {
+      "name": "test",
+      "x-displayName": "The test Model",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/Parent\" />\n"
+    }
+  ],
+  "paths": {
+    "/newPath": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Child"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "all ok"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Parent": {
+        "$ref": "#/components/schemas/Child"
+      },
+      "Child": {
+        "type": "object",
+        "properties": {
+          "test": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/services/__tests__/models/Schema.test.ts
+++ b/src/services/__tests__/models/Schema.test.ts
@@ -40,5 +40,13 @@ describe('Models', () => {
       expect(schema.oneOf).toHaveLength(2);
       expect(schema.displayType).toBe('(Array of strings or numbers) or string');
     });
+
+    test('schemaDefinition should resolve double ref', () => {
+      const spec = require('../fixtures/3.1/schemaDefinition.json');
+      parser = new OpenAPIParser(spec, undefined, opts);
+      const schema = new SchemaModel(parser, spec.components.schemas.Parent, '', opts);
+      expect(schema.fields).toHaveLength(1);
+      expect(schema.pointer).toBe('#/components/schemas/Child');
+    });
   });
 });


### PR DESCRIPTION
## What/Why/How?
fixes: https://github.com/Redocly/redoc/issues/1862

## Reference

## Testing

`openapi.yaml`
```
openapi: 3.1.0
info:
  title: Try to reproduce
  version: 1.0.0
servers:
  - url: example.com
tags:
  - name: test
    x-displayName: The test Model
    description: |
      <SchemaDefinition schemaRef="#/components/schemas/test" />

paths:
  /newPath:
    post:
      requestBody:
        content: 
          application/json:
            schema:
              $ref: "#/components/schemas/test"
      responses:
        200:
          description: 'all ok'

components:
  schemas:
    test:
      $ref: ./test.yml#/Test

```
`test.yaml`
```
Test:
  type: object
  properties:
    test:
      type: string
```

## Screenshots (optional)

<img width="1792" alt="Screenshot 2022-02-03 at 13 22 46" src="https://user-images.githubusercontent.com/14113673/152333835-10ec6a1f-c49d-4eb5-86eb-e765a57604d5.png">


## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
