### PR TITLE
chore: update openapi-sampler to v1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mark.js": "^8.11.1",
         "marked": "^4.0.10",
         "mobx-react": "^7.2.0",
-        "openapi-sampler": "^1.1.1",
+        "openapi-sampler": "^1.2.1",
         "path-browserify": "^1.0.1",
         "perfect-scrollbar": "^1.5.1",
         "polished": "^4.1.3",
@@ -14191,12 +14191,12 @@
       }
     },
     "node_modules/openapi-sampler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.1.1.tgz",
-      "integrity": "sha512-WAFsl5SPYuhQwaMTDFOcKhnEY1G1rmamrMiPmJdqwfl1lr81g63/befcsN9BNi0w5/R0L+hfcUj13PANEBeLgg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.2.1.tgz",
+      "integrity": "sha512-mHrYmyvcLD0qrfqPkPRBAL2z16hGT2rW0d0B7nklfoTcc3pmkJLkSZlKSeFgerUM41E5c7jlxf0Y19xrM7mWQQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "json-pointer": "^0.6.1"
+        "json-pointer": "0.6.2"
       }
     },
     "node_modules/optionator": {
@@ -29794,12 +29794,12 @@
       }
     },
     "openapi-sampler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.1.1.tgz",
-      "integrity": "sha512-WAFsl5SPYuhQwaMTDFOcKhnEY1G1rmamrMiPmJdqwfl1lr81g63/befcsN9BNi0w5/R0L+hfcUj13PANEBeLgg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.2.1.tgz",
+      "integrity": "sha512-mHrYmyvcLD0qrfqPkPRBAL2z16hGT2rW0d0B7nklfoTcc3pmkJLkSZlKSeFgerUM41E5c7jlxf0Y19xrM7mWQQ==",
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "json-pointer": "^0.6.1"
+        "json-pointer": "0.6.2"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "mark.js": "^8.11.1",
     "marked": "^4.0.10",
     "mobx-react": "^7.2.0",
-    "openapi-sampler": "^1.1.1",
+    "openapi-sampler": "^1.2.1",
     "path-browserify": "^1.0.1",
     "perfect-scrollbar": "^1.5.1",
     "polished": "^4.1.3",


### PR DESCRIPTION
## What/Why/How?
update openapi-sampler to v1.2.1

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
