### PR TITLE
fix: sanitize array of items

### DIFF
--- a/src/components/Fields/ArrayItemDetails.tsx
+++ b/src/components/Fields/ArrayItemDetails.tsx
@@ -11,7 +11,7 @@ export function ArrayItemDetails({ schema }: { schema: SchemaModel }) {
   return (
     <Wrapper>
       [ items
-      {schema.displayFormat && <TypeFormat>{` &lt;${schema.displayFormat}&gt; `}</TypeFormat>}
+      {schema.displayFormat && <TypeFormat> &lt;{schema.displayFormat} &gt;</TypeFormat>}
       <ConstraintsView constraints={schema.constraints} />
       <Pattern schema={schema} />
       {schema.items && <ArrayItemDetails schema={schema.items} />} ]


### PR DESCRIPTION
## What/Why/How?
fixes: https://github.com/Redocly/redoc/issues/1919

We had the wrong syntax for "<" and ">" quotes.

## Reference

## Testing

## Screenshots (optional)
### Before
<img width="874" alt="Screenshot 2022-03-08 at 11 52 28" src="https://user-images.githubusercontent.com/14113673/157212310-8b56e19c-b6bb-4faa-b9d8-00169832a7a4.png">

### After
<img width="874" alt="Screenshot 2022-03-08 at 11 52 48" src="https://user-images.githubusercontent.com/14113673/157212349-9cd6b8b1-ae6a-4e77-927a-df10b3b01a8f.png">

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
