### PR TITLE
fix: move comma out of code block in SecurityRequirement.tsx

### DIFF
--- a/src/components/SecurityRequirement/SecurityRequirement.tsx
+++ b/src/components/SecurityRequirement/SecurityRequirement.tsx
@@ -6,6 +6,23 @@ import { Link, UnderlinedHeader } from '../../common-elements/';
 import { SecurityRequirementModel } from '../../services/models/SecurityRequirement';
 import { linksCss } from '../Markdown/styled.elements';
 
+const ScopeNameList = styled.ul`
+  display: inline;
+  list-style: none;
+  padding: 0;
+
+  li {
+    display: inherit;
+
+    &:after {
+      content: ',';
+    }
+    &:last-child:after {
+      content: none;
+    }
+  }
+`;
+
 const ScopeName = styled.code`
   font-size: ${props => props.theme.typography.code.fontSize};
   font-family: ${props => props.theme.typography.code.fontFamily};
@@ -14,13 +31,6 @@ const ScopeName = styled.code`
   padding: 0.2em;
   display: inline-block;
   line-height: 1;
-
-  &:after {
-    content: ',';
-  }
-  &:last-child:after {
-    content: none;
-  }
 `;
 
 const SecurityRequirementAndWrap = styled.span`
@@ -72,9 +82,13 @@ export class SecurityRequirement extends React.PureComponent<SecurityRequirement
               <SecurityRequirementAndWrap key={scheme.id}>
                 <Link to={scheme.sectionId}>{scheme.id}</Link>
                 {scheme.scopes.length > 0 && ' ('}
-                {scheme.scopes.map(scope => (
-                  <ScopeName key={scope}>{scope}</ScopeName>
-                ))}
+                <ScopeNameList>
+                  {scheme.scopes.map(scope => (
+                    <li key={scope}>
+                      <ScopeName>{scope}</ScopeName>
+                    </li>
+                  ))}
+                </ScopeNameList>
                 {scheme.scopes.length > 0 && ') '}
               </SecurityRequirementAndWrap>
             );


### PR DESCRIPTION
## What/Why/How?
Simply moved the comma separating scope names outside of the code block in the SecurityRequirement component

## Reference

## Testing

## Screenshots (optional)
Before:
![image](https://user-images.githubusercontent.com/16763483/157493789-daebbcec-e3f2-47b5-b70b-6f5a97107fbe.png)
After:
![image](https://user-images.githubusercontent.com/16763483/157493916-54049a50-c62b-44fb-a04d-2579863a0ba0.png)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
