### PR TITLE
feat: Add support for displaying operationId in the sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ You can use all of the following options with the standalone version of the <red
 * `sideNavStyle` - can be specified in various ways:
   * **summary-only**: displays a summary in the sidebar navigation item. (**default**)
   * **path-only**: displays a path in the sidebar navigation item.
+  * **id-only**: displays the operation id with a fallback to the path in the sidebar navigation item.
 
 ### `<redoc>` theme object
 * `spacing`

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -170,6 +170,8 @@ export class RedocNormalizedOptions {
         return value;
       case SideNavStyleEnum.PathOnly:
         return SideNavStyleEnum.PathOnly;
+      case SideNavStyleEnum.IdOnly:
+        return SideNavStyleEnum.IdOnly;
       default:
         return defaultValue;
     }

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -8,6 +8,7 @@ import { MDXComponentMeta } from './MarkdownRenderer';
 export enum SideNavStyleEnum {
   SummaryOnly = 'summary-only',
   PathOnly = 'path-only',
+  IdOnly = 'id-only',
 }
 
 export interface RedocRawOptions {

--- a/src/services/models/Operation.ts
+++ b/src/services/models/Operation.ts
@@ -106,7 +106,12 @@ export class OperationModel implements IMenuItem {
 
     this.name = getOperationSummary(operationSpec);
 
-    this.sidebarLabel = options.sideNavStyle === SideNavStyleEnum.PathOnly ? this.path : this.name;
+    this.sidebarLabel =
+      options.sideNavStyle === SideNavStyleEnum.IdOnly
+        ? this.operationId || this.path
+        : options.sideNavStyle === SideNavStyleEnum.PathOnly
+        ? this.path
+        : this.name;
 
     if (this.isCallback) {
       // NOTE: Callbacks by default should not inherit the specification's global `security` definition.


### PR DESCRIPTION
## What/Why/How?

As with most companies that use OpenAPI we make use of the `operationId` to actually know what code to call through auto-generated code, which made this library unusable for generating documentation despite all the other benefits.

Simply added an option to the enum arguments to allow it to display the `operationId` - which is marked as optional in the spec, so provided a fallback to the `path` (the Summary is not useful in technical documentation), and added to the documentation.

No testing has been added for this - as I couldn't find any tests for the already existing functionality - the already existing tests have enough problems that my best comment is "this didn't break anything that wasn't already broken".

## Check yourself

- [x] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
