### PR TITLE
fix: rename bandle command and add deprecate notice

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -158,7 +158,7 @@ YargsParser.command(
   [
     res => {
       console.log(
-        `\n⚠️ This command is deprecated. Use openapi-cli for it: npx @redocly/openapi-cli preview-docs petstore.yaml⚠️\n`,
+        `\n⚠️ This command is deprecated. Use "npx @redocly/openapi-cli preview-docs petstore.yaml"\n`,
       );
       return res;
     },
@@ -177,9 +177,7 @@ YargsParser.command(
     handlerForBuildCommand,
     [
       res => {
-        console.log(
-          `\n⚠️ This command is deprecated. Use "build" command instead.\n`,
-        );
+        console.log(`\n⚠️ This command is deprecated. Use "build" command instead.\n`);
         return res;
       },
     ],


### PR DESCRIPTION
## What/Why/How?
Rename bundle command to build for consistency. In the future, we should remove the bundle command.

## Reference

## Testing

## Screenshots (optional)
<img width="1117" alt="Screenshot 2022-03-17 at 18 07 14" src="https://user-images.githubusercontent.com/14113673/158989076-8feb724a-d8bf-4cf2-aba9-207e25676711.png">
<img width="1117" alt="Screenshot 2022-03-21 at 14 35 44" src="https://user-images.githubusercontent.com/14113673/159262221-3326253b-2b8e-49e2-8f27-8cf0007e5267.png">



## Check yourself

- [x] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
