### PR TITLE
fix: improve markdown render with CRLF

### DIFF
--- a/src/services/MarkdownRenderer.ts
+++ b/src/services/MarkdownRenderer.ts
@@ -101,7 +101,9 @@ export class MarkdownRenderer {
 
   attachHeadingsDescriptions(rawText: string) {
     const buildRegexp = (heading: MarkdownHeading) => {
-      return new RegExp(`##?\\s+${heading.name.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')}\s*\n`);
+      return new RegExp(
+        `##?\\s+${heading.name.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')}\s*(\n|\r\n)`,
+      );
     };
 
     const flatHeadings = this.flattenHeadings(this.headings);


### PR DESCRIPTION
## What/Why/How?
fixes: https://github.com/Redocly/redoc/issues/1952.
In [#1845](https://github.com/Redocly/redoc/pull/1845) we improve our build heading regex but not include all CRLF symbols. This PR should fix it.
## Reference

## Testing

```yaml
{
  "openapi": "3.0.1",
  "info": {
    "title": "Minimal Example JSON",
    "description": "# Getting Started\r\n## Authentication\r\nAll API Requests _must_ contain an Authorization Header with a valid access token",
    "contact": {
      "name": "Name",
      "email": "email@example.com"
    },
    "version": "v3.0: 3.10.0.0"
  }
}
```

## Screenshots (optional)
**Before**
<img width="1180" alt="Screenshot 2022-03-31 at 11 48 03" src="https://user-images.githubusercontent.com/14113673/161015834-1aebcf35-a176-446d-9a1d-f94477dee218.png">

**After**
<img width="1101" alt="Screenshot 2022-03-31 at 11 47 43" src="https://user-images.githubusercontent.com/14113673/161015897-1feb332e-e063-4649-910c-99f3a3c53cfc.png">

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
