### PR TITLE
fix: hoist and combine allOf subschema titles

### DIFF
--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -269,6 +269,7 @@ export class OpenAPIParser {
       schema: MergedOpenAPISchema;
     }>;
 
+    const subSchemaTitles: string[] = [];
     for (const { $ref: subSchemaRef, schema: subSchema } of allOfSchemas) {
       if (
         receiver.type !== subSchema.type &&
@@ -326,6 +327,14 @@ export class OpenAPIParser {
           // receiver.title = JsonPointer.baseName(subSchemaRef);
         }
       }
+
+      if (subSchema.title !== undefined) {
+        subSchemaTitles.push(subSchema.title);
+      }
+    }
+
+    if (receiver.title === undefined && subSchemaTitles.length) {
+      receiver.title = subSchemaTitles.join('+');
     }
 
     return receiver;


### PR DESCRIPTION
## What/Why/How?

Issues #932 and #1256 raise the point that the typically achieved rendering of the schemas resulting from nestend `oneOf` and `allOf` are unexpectedly ugly, namely `object`.

In https://github.com/Redocly/redoc/issues/932#issuecomment-516315671 the point is raised that simply using one of the titles of multiple `allOf` options (e.g. the first one) might be wrong as the other elements might also have added semantics.

Hence this PR collects all schema titles from the subschemas below `allOf` (pulled down via `hoistOneOf` or not) and combines them via `+` for display. Schemas without title are not included, giving the API developer some flexibility to consider them for inclusion in display.

## Reference

Closes #932 (differently)
Closes #1256

## Testing

## Screenshots (optional)

Source:
```
allOf:
  - type: object
    title: Existing
    properties:
      id:
        type: string
        format: uuid
  - description: Payment instrument (eg. card) data to use.
    title: Payment instrument
    type: object
    oneOf:
      - title: Credit card
        type: object
        properties:
          type:
            type: string
            const: cardInstrument
... [and three more types] ...
```

![combined-titles](https://user-images.githubusercontent.com/609223/166472695-b767e9ac-db01-4f33-9b78-88cefa6b6683.png)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
