### PR TITLE
chore: upgrade openapi-sampler to v1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "mark.js": "^8.11.1",
         "marked": "^4.0.15",
         "mobx-react": "^7.2.0",
-        "openapi-sampler": "^1.2.1",
+        "openapi-sampler": "^1.2.3",
         "path-browserify": "^1.0.1",
         "perfect-scrollbar": "^1.5.1",
         "polished": "^4.1.3",
@@ -14195,9 +14195,9 @@
       }
     },
     "node_modules/openapi-sampler": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.2.1.tgz",
-      "integrity": "sha512-mHrYmyvcLD0qrfqPkPRBAL2z16hGT2rW0d0B7nklfoTcc3pmkJLkSZlKSeFgerUM41E5c7jlxf0Y19xrM7mWQQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.2.3.tgz",
+      "integrity": "sha512-dH2QYXqakorV5dxkP/f1BV3Ku4yNn21YmBsqJunnyrHLw7mnCNZZldftgrEpv/66b1m5oaUAmiJoJN+FqBEkJg==",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
         "json-pointer": "0.6.2"
@@ -29831,9 +29831,9 @@
       }
     },
     "openapi-sampler": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.2.1.tgz",
-      "integrity": "sha512-mHrYmyvcLD0qrfqPkPRBAL2z16hGT2rW0d0B7nklfoTcc3pmkJLkSZlKSeFgerUM41E5c7jlxf0Y19xrM7mWQQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.2.3.tgz",
+      "integrity": "sha512-dH2QYXqakorV5dxkP/f1BV3Ku4yNn21YmBsqJunnyrHLw7mnCNZZldftgrEpv/66b1m5oaUAmiJoJN+FqBEkJg==",
       "requires": {
         "@types/json-schema": "^7.0.7",
         "json-pointer": "0.6.2"

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "mark.js": "^8.11.1",
     "marked": "^4.0.15",
     "mobx-react": "^7.2.0",
-    "openapi-sampler": "^1.2.1",
+    "openapi-sampler": "^1.2.3",
     "path-browserify": "^1.0.1",
     "perfect-scrollbar": "^1.5.1",
     "polished": "^4.1.3",


### PR DESCRIPTION
## What/Why/How?
upgrade openapi-sampler to v1.2.3 for fix issue with oneOf example
fixes https://github.com/Redocly/redoc/issues/1999
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
