### PR TITLE
chore: enable cli test for build command with url

### DIFF
--- a/cli/__test__/build/configRedoc/url.test.ts
+++ b/cli/__test__/build/configRedoc/url.test.ts
@@ -1,8 +1,7 @@
 import { spawnSync } from 'child_process';
 
 describe('build with url', () => {
-  // FIXME: remove skip after release
-  it.skip('should not fail on resolving url', () => {
+  it('should not fail on resolving url', () => {
     const r = spawnSync(
       'ts-node',
       [


### PR DESCRIPTION
## What/Why/How?
we have an issue about failing bundle command which includes definition as URL. We added a test for it. And now we should enable this test.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
