### PR TITLE
chore: cli-v0.13.14

### DIFF
--- a/cli/npm-shrinkwrap.json
+++ b/cli/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "redoc-cli",
-  "version": "0.13.13",
+  "version": "0.13.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redoc-cli",
-      "version": "0.13.13",
+      "version": "0.13.14",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.1",
@@ -17,7 +17,7 @@
         "node-libs-browser": "^2.2.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "redoc": "2.0.0-rc.69",
+        "redoc": "2.0.0-rc.70",
         "styled-components": "^5.3.0",
         "yargs": "^17.3.1"
       },
@@ -2201,9 +2201,9 @@
       }
     },
     "node_modules/redoc": {
-      "version": "2.0.0-rc.69",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.69.tgz",
-      "integrity": "sha512-AFedbb9h0I98z0lBF2hkkn3M09CsF/zXfRCd07vGL0fZg72/VFPAmHN7CyFRGg/whVEstZ2iUhN2jbN6MmTTDQ==",
+      "version": "2.0.0-rc.70",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.70.tgz",
+      "integrity": "sha512-sdmZ8FX4JjF50hTSjHJ64Ccu9Ewa2O8+Fo8pCLg8GHFrbaFJ2E+KBDK9pGuAqNi61fm3Z5c91Ur7zqpITkUpNg==",
       "dependencies": {
         "@redocly/openapi-core": "^1.0.0-beta.97",
         "classnames": "^2.3.1",
@@ -4793,9 +4793,9 @@
       }
     },
     "redoc": {
-      "version": "2.0.0-rc.69",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.69.tgz",
-      "integrity": "sha512-AFedbb9h0I98z0lBF2hkkn3M09CsF/zXfRCd07vGL0fZg72/VFPAmHN7CyFRGg/whVEstZ2iUhN2jbN6MmTTDQ==",
+      "version": "2.0.0-rc.70",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.70.tgz",
+      "integrity": "sha512-sdmZ8FX4JjF50hTSjHJ64Ccu9Ewa2O8+Fo8pCLg8GHFrbaFJ2E+KBDK9pGuAqNi61fm3Z5c91Ur7zqpITkUpNg==",
       "requires": {
         "@redocly/openapi-core": "^1.0.0-beta.97",
         "classnames": "^2.3.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redoc-cli",
-  "version": "0.13.13",
+  "version": "0.13.14",
   "description": "ReDoc's Command Line Interface",
   "main": "index.js",
   "bin": "index.js",
@@ -19,7 +19,7 @@
     "node-libs-browser": "^2.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "redoc": "2.0.0-rc.69",
+    "redoc": "2.0.0-rc.70",
     "styled-components": "^5.3.0",
     "yargs": "^17.3.1"
   },


### PR DESCRIPTION
## What/Why/How?
release redoc-cli to v0.13.14
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
