### PR TITLE
fix: merge allOf in correct order

### DIFF
--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -274,6 +274,9 @@ export class OpenAPIParser {
         properties,
         items,
         required,
+        oneOf,
+        anyOf,
+        title,
         ...otherConstraints
       } = subSchema;
 
@@ -324,9 +327,17 @@ export class OpenAPIParser {
         receiver.required = (receiver.required || []).concat(required);
       }
 
+      if (oneOf !== undefined) {
+        receiver.oneOf = oneOf;
+      }
+
+      if (anyOf !== undefined) {
+        receiver.anyOf = anyOf;
+      }
+
       // merge rest of constraints
       // TODO: do more intelligent merge
-      receiver = { ...receiver, ...otherConstraints };
+      receiver = { ...receiver, title: receiver.title || title, ...otherConstraints };
 
       if (subSchemaRef) {
         receiver.parentRefs!.push(subSchemaRef);

--- a/src/services/__tests__/OpenAPIParser.test.ts
+++ b/src/services/__tests__/OpenAPIParser.test.ts
@@ -9,14 +9,50 @@ describe('Models', () => {
     let parser;
 
     test('should hoist oneOfs when mergin allOf', () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const spec = require('./fixtures/oneOfHoist.json');
       parser = new OpenAPIParser(spec, undefined, opts);
       expect(parser.mergeAllOf(spec.components.schemas.test)).toMatchSnapshot();
     });
 
+    test('should get schema name from named schema', () => {
+      const spec = require('./fixtures/mergeAllOf.json');
+      parser = new OpenAPIParser(spec, undefined, opts);
+      const schema = parser.mergeAllOf(spec.components.schemas.Case1, '#/components/schemas/Case1');
+      expect(schema.title).toEqual('Case1');
+    });
+
+    test('should get schema name from first allOf', () => {
+      const spec = require('./fixtures/mergeAllOf.json');
+      parser = new OpenAPIParser(spec, undefined, opts);
+      const schema = parser.mergeAllOf(
+        spec.components.schemas.Case2.properties.a,
+        '#components/schemas/Case2/properties/a',
+      );
+      expect(schema.title).toEqual('Bar');
+    });
+
+    test('should get schema name from named schema', () => {
+      const spec = require('./fixtures/mergeAllOf.json');
+      parser = new OpenAPIParser(spec, undefined, opts);
+      const schema = parser.mergeAllOf(
+        spec.components.schemas.Case3.schemas.Foo,
+        '#components/schemas/Case3/schemas/Foo',
+      );
+      expect(schema.title).toEqual('Foo');
+    });
+
+    test('should merge oneOff to inside allOff', () => {
+      // TODO: should hoist
+      const spec = require('./fixtures/mergeAllOf.json');
+      parser = new OpenAPIParser(spec, undefined, opts);
+      const schema = parser.mergeAllOf(spec.components.schemas.Case4);
+      expect(schema.title).toEqual('Foo');
+      expect(schema.parentRefs).toHaveLength(1);
+      expect(schema.parentRefs[0]).toEqual('#/components/schemas/Ref');
+      expect(schema.oneOf).toEqual([{ title: 'Bar' }, { title: 'Baz' }]);
+    });
+
     test('should override description from $ref of the referenced component, when sibling description exists ', () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const spec = require('./fixtures/siblingRefDescription.json');
       parser = new OpenAPIParser(spec, undefined, opts);
       const schemaOrRef: Referenced<OpenAPIParameter> = {
@@ -28,7 +64,6 @@ describe('Models', () => {
     });
 
     test('should correct resolve double $ref if no need sibling', () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const spec = require('./fixtures/3.1/schemaDefinition.json');
       parser = new OpenAPIParser(spec, undefined, opts);
       const schemaOrRef: Referenced<OpenAPIParameter> = {

--- a/src/services/__tests__/fixtures/mergeAllOf.json
+++ b/src/services/__tests__/fixtures/mergeAllOf.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "Foo"
+  },
+  "components": {
+    "schemas": {
+      "Case1": {
+        "allOf": [
+          {
+            "title": "Bar"
+          },
+          {
+            "title": "Baz"
+          }
+        ]
+      },
+      "Case2": {
+        "properties": {
+          "a": {
+            "allOf": [
+              {
+                "title": "Bar"
+              },
+              {
+                "title": "Baz"
+              }
+            ]
+          }
+        }
+      },
+      "Case3": {
+        "schemas": {
+          "Foo": {
+            "title": "Foo",
+            "allOf": [
+              {
+                "title": "Bar"
+              },
+              {
+                "title": "Baz"
+              }
+            ]
+          }
+        }
+      },
+      "Case4": {
+        "allOf": [
+          {
+            "title": "Foo"
+          },
+          {
+            "$ref": "#/components/schemas/Ref"
+          }
+        ]
+      },
+      "Ref": {
+        "oneOf": [
+          {
+            "title": "Bar"
+          },
+          {
+            "title": "Baz"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What/Why/How?
after releasing the conditional operators we have a problem with merging oneOf, anyOf, and other parts of the schema.

fixes https://github.com/Redocly/redoc/issues/2017

## Reference

## Testing

## Screenshots (optional)
<img width="1516" alt="Screenshot 2022-05-23 at 15 32 44" src="https://user-images.githubusercontent.com/14113673/169820067-00c8dc4d-3f82-4825-b516-69a0454cc4fe.png">

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
