### PR TITLE
Supports React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,8 +135,8 @@
   "peerDependencies": {
     "core-js": "^3.1.4",
     "mobx": "^6.0.4",
-    "react": "^16.8.4 || ^17.0.0",
-    "react-dom": "^16.8.4 || ^17.0.0",
+    "react": "^16.8.4 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0",
     "styled-components": "^4.1.1 || ^5.1.1"
   },
   "dependencies": {


### PR DESCRIPTION
## What/Why/How?

npm install crashes right if using version 18