### PR TITLE
Mis-nesting of aria roles on sidebar navigation

### DIFF
--- a/e2e/integration/search.e2e.ts
+++ b/e2e/integration/search.e2e.ts
@@ -45,7 +45,7 @@ describe('Search', () => {
 
     getSearchInput().type('{enter}', { force: true });
 
-    cy.contains('[role=navigation] [role=menuitem]', 'Introduction').should('have.class', 'active');
+    cy.contains('[role=menu] [role=menuitem]', 'Introduction').should('have.class', 'active');
   });
 
   it('should mark search results', () => {

--- a/src/components/SideMenu/MenuItems.tsx
+++ b/src/components/SideMenu/MenuItems.tsx
@@ -26,7 +26,7 @@ export class MenuItems extends React.Component<MenuItemsProps> {
         className={className}
         style={this.props.style}
         expanded={expanded}
-        {...(root ? { role: 'navigation' } : {})}
+        {...(root ? { role: 'menu' } : {})}
       >
         {items.map((item, idx) => (
           <MenuItem key={idx} item={item} onActivate={this.props.onActivate} />


### PR DESCRIPTION
The sidebar navigation uses `menuItem` but without the correct grouping parent role, instead using a `navigation` role.
The use of the `navigation` role on the `ul` also changes the role of that element from an implicit list to an explicit non-list, so rendering the implicit child list items without a correctly named parent.

Before:
<img width="695" alt="Screenshot 2022-06-13 at 13 33 44" src="https://user-images.githubusercontent.com/25553660/173354558-d13a7e35-ea99-45f7-bd91-799370fbd33a.png">

After:
<img width="688" alt="Screenshot 2022-06-13 at 13 34 33" src="https://user-images.githubusercontent.com/25553660/173354696-b75e951a-7bba-4b7d-b8ff-a725f8965be6.png">

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
