### PR TITLE
fix: resolve dependency conflict in installing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,8 @@
         "url-template": "^2.0.8"
       },
       "devDependencies": {
-        "@cypress/webpack-preprocessor": "^5.9.0",
-        "@hot-loader/react-dom": "^17.0.1",
+        "@cypress/webpack-preprocessor": "^5.12.0",
+        "@hot-loader/react-dom": "^17.0.2",
         "@size-limit/preset-app": "^7.0.4",
         "@types/chai": "^4.2.18",
         "@types/dompurify": "^2.2.2",
@@ -1598,21 +1598,27 @@
       }
     },
     "node_modules/@cypress/webpack-preprocessor": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.9.0.tgz",
-      "integrity": "sha512-9mzk9PdbCv+FMXZnlg0BK0PkKvOM7AYjc0c8vDhdcQh2ZId8TvV64t81wyWwN8g2H49Ns0ynhXZCJLu+luO83g==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.12.0.tgz",
+      "integrity": "sha512-D/eLKKlgx6c/307FaCmjZGjFA64G29aA8KcCy6WqpNK/bSnRdPquMW2plemIsT/B80TK2DDKzZX/H3FcS41ZDA==",
       "dev": true,
       "dependencies": {
-        "bluebird": "^3.7.1",
-        "debug": "4.3.2",
+        "bluebird": "3.7.1",
+        "debug": "^4.3.2",
         "lodash": "^4.17.20"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.1",
         "@babel/preset-env": "^7.0.0",
         "babel-loader": "^8.0.2",
-        "webpack": "^4.18.1"
+        "webpack": "^4 || ^5"
       }
+    },
+    "node_modules/@cypress/webpack-preprocessor/node_modules/bluebird": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
+      "dev": true
     },
     "node_modules/@cypress/xvfb": {
       "version": "1.2.4",
@@ -1769,17 +1775,17 @@
       "integrity": "sha512-GoXw0U2Qaa33m3eUcxuHnHpNvHjNlLo0gtV091XBpaRINaB4X6FGCG5XKxSFNFiPpugUDqNruHzaqpTdDm4AOg=="
     },
     "node_modules/@hot-loader/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-QttzEibkIFkl/WV1dsLXg73YIweNo9ySbB0/26068RqFGWyv7pKyictWsaQXqSj1y66/BDn3kglCHgroGrv3vA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-G2RZrFhsQClS+bdDh/Ojpk3SgocLPUGnvnJDTQYnmKSSwXtU+Yh+8QMs+Ia3zaAvBiOSpIIDSUxuN69cvKqrWg==",
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "17.0.1"
+        "react": "17.0.2"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -5225,9 +5231,9 @@
       }
     },
     "node_modules/conventional-changelog-cli": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-2.1.1.tgz",
-      "integrity": "sha512-xMGQdKJ+4XFDDgfX5aK7UNFduvJMbvF5BB+g0OdVhA3rYdYyhctrIE2Al+WYdZeKTdg9YzMWF2iFPT8MupIwng==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-2.2.2.tgz",
+      "integrity": "sha512-8grMV5Jo8S0kP3yoMeJxV2P5R6VJOqK72IiSV9t/4H5r/HiRqEBQ83bYGuz4Yzfdj4bjaAEhZN/FFbsFXr5bOA==",
       "dev": true,
       "dependencies": {
         "add-stream": "^1.0.0",
@@ -8863,7 +8869,7 @@
     "node_modules/get-pkg-repo/node_modules/trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "integrity": "sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -20229,14 +20235,22 @@
       }
     },
     "@cypress/webpack-preprocessor": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.9.0.tgz",
-      "integrity": "sha512-9mzk9PdbCv+FMXZnlg0BK0PkKvOM7AYjc0c8vDhdcQh2ZId8TvV64t81wyWwN8g2H49Ns0ynhXZCJLu+luO83g==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.12.0.tgz",
+      "integrity": "sha512-D/eLKKlgx6c/307FaCmjZGjFA64G29aA8KcCy6WqpNK/bSnRdPquMW2plemIsT/B80TK2DDKzZX/H3FcS41ZDA==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.7.1",
-        "debug": "4.3.2",
+        "bluebird": "3.7.1",
+        "debug": "^4.3.2",
         "lodash": "^4.17.20"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+          "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
+          "dev": true
+        }
       }
     },
     "@cypress/xvfb": {
@@ -20368,14 +20382,14 @@
       "integrity": "sha512-GoXw0U2Qaa33m3eUcxuHnHpNvHjNlLo0gtV091XBpaRINaB4X6FGCG5XKxSFNFiPpugUDqNruHzaqpTdDm4AOg=="
     },
     "@hot-loader/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-QttzEibkIFkl/WV1dsLXg73YIweNo9ySbB0/26068RqFGWyv7pKyictWsaQXqSj1y66/BDn3kglCHgroGrv3vA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-G2RZrFhsQClS+bdDh/Ojpk3SgocLPUGnvnJDTQYnmKSSwXtU+Yh+8QMs+Ia3zaAvBiOSpIIDSUxuN69cvKqrWg==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.20.2"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -23140,9 +23154,9 @@
       }
     },
     "conventional-changelog-cli": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-2.1.1.tgz",
-      "integrity": "sha512-xMGQdKJ+4XFDDgfX5aK7UNFduvJMbvF5BB+g0OdVhA3rYdYyhctrIE2Al+WYdZeKTdg9YzMWF2iFPT8MupIwng==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-2.2.2.tgz",
+      "integrity": "sha512-8grMV5Jo8S0kP3yoMeJxV2P5R6VJOqK72IiSV9t/4H5r/HiRqEBQ83bYGuz4Yzfdj4bjaAEhZN/FFbsFXr5bOA==",
       "dev": true,
       "requires": {
         "add-stream": "^1.0.0",
@@ -25896,7 +25910,7 @@
         "trim-newlines": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+          "integrity": "sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "pre-commit": "pretty-quick --staged && npm run lint"
   },
   "devDependencies": {
-    "@cypress/webpack-preprocessor": "^5.9.0",
-    "@hot-loader/react-dom": "^17.0.1",
+    "@cypress/webpack-preprocessor": "^5.12.0",
+    "@hot-loader/react-dom": "^17.0.2",
     "@size-limit/preset-app": "^7.0.4",
     "@types/chai": "^4.2.18",
     "@types/dompurify": "^2.2.2",


### PR DESCRIPTION
## What/Why/How?
Resolve dependency conflict for `npm i` and `npm ci` commands. It was related to the latest version of node.js (16.15.1)
## Reference

## Testing

## Screenshots (optional)
_Before_
<img width="764" alt="Screenshot 2022-06-22 at 11 42 50" src="https://user-images.githubusercontent.com/14113673/174985192-906bc881-9715-4852-864e-5621c8a53cad.png">
<img width="764" alt="Screenshot 2022-06-22 at 11 42 56" src="https://user-images.githubusercontent.com/14113673/174985208-434ca870-3bf1-46cf-b7a2-6acd29fa60ab.png">

## Check yourself

- [x] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
