### PR TITLE
fix: markdown parent name

### DIFF
--- a/src/components/ContentItems/ContentItems.tsx
+++ b/src/components/ContentItems/ContentItems.tsx
@@ -79,7 +79,11 @@ export class SectionItem extends React.Component<ContentItemProps> {
             </Header>
           </MiddlePanel>
         </Row>
-        <AdvancedMarkdown source={description || ''} htmlWrap={middlePanelWrap} />
+        <AdvancedMarkdown
+          parentId={this.props.item.id}
+          source={description || ''}
+          htmlWrap={middlePanelWrap}
+        />
         {externalDocs && (
           <Row>
             <MiddlePanel>

--- a/src/components/Markdown/AdvancedMarkdown.tsx
+++ b/src/components/Markdown/AdvancedMarkdown.tsx
@@ -9,6 +9,7 @@ import { StoreConsumer } from '../StoreBuilder';
 
 export interface AdvancedMarkdownProps extends BaseMarkdownProps {
   htmlWrap?: (part: JSX.Element) => JSX.Element;
+  parentId?: string;
 }
 
 export class AdvancedMarkdown extends React.Component<AdvancedMarkdownProps> {
@@ -28,7 +29,7 @@ export class AdvancedMarkdown extends React.Component<AdvancedMarkdownProps> {
       throw new Error('When using components in markdown, store prop must be provided');
     }
 
-    const renderer = new MarkdownRenderer(options);
+    const renderer = new MarkdownRenderer(options, this.props.parentId);
     const parts = renderer.renderMdWithComponents(source);
 
     if (!parts.length) {

--- a/src/services/MarkdownRenderer.ts
+++ b/src/services/MarkdownRenderer.ts
@@ -61,7 +61,8 @@ export class MarkdownRenderer {
   private headingEnhanceRenderer: marked.Renderer;
   private originalHeadingRule: typeof marked.Renderer.prototype.heading;
 
-  constructor(public options?: RedocNormalizedOptions) {
+  constructor(public options?: RedocNormalizedOptions, public parentId?: string) {
+    this.parentId = parentId;
     this.parser = new marked.Parser();
     this.headingEnhanceRenderer = new marked.Renderer();
     this.originalHeadingRule = this.headingEnhanceRenderer.heading.bind(
@@ -78,7 +79,9 @@ export class MarkdownRenderer {
   ): MarkdownHeading {
     name = unescapeHTMLChars(name);
     const item = {
-      id: parentId ? `${parentId}/${safeSlugify(name)}` : `section/${safeSlugify(name)}`,
+      id: parentId
+        ? `${parentId}/${safeSlugify(name)}`
+        : `${this.parentId || 'section'}/${safeSlugify(name)}`,
       name,
       level,
       items: [],

--- a/src/services/MenuBuilder.ts
+++ b/src/services/MenuBuilder.ts
@@ -70,7 +70,7 @@ export class MenuBuilder {
     initialDepth: number,
     options: RedocNormalizedOptions,
   ): ContentItemModel[] {
-    const renderer = new MarkdownRenderer(options);
+    const renderer = new MarkdownRenderer(options, parent?.id);
     const headings = renderer.extractHeadings(description || '');
 
     if (headings.length && parent && parent.description) {


### PR DESCRIPTION
## What/Why/How?

* Fix the parentId error of markdown header
* The same markdown title in different directories of the current version will generate the same index

## Screenshots (optional)

* Before
<img width="1438" alt="a4178256-9f45-4c95-a7e6-d376e7733037" src="https://user-images.githubusercontent.com/16759376/175457743-b2d1532b-1593-4fdb-96e6-af2717d9534a.png">

* After
<img width="1439" alt="8067b651-4be6-493b-992d-4726854599bc" src="https://user-images.githubusercontent.com/16759376/175457734-32713cef-d6a8-4d6b-84cd-0f4797e48daa.png">

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
