### PR TITLE
fix: property with nested allOf

### DIFF
--- a/src/components/__tests__/__snapshots__/DiscriminatorDropdown.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DiscriminatorDropdown.test.tsx.snap
@@ -843,6 +843,7 @@ exports[`Components SchemaView discriminator should correctly render SchemaView 
             ],
             "schema": Object {
               "allOf": undefined,
+              "description": undefined,
               "discriminator": Object {
                 "propertyName": "type",
               },
@@ -858,11 +859,13 @@ exports[`Components SchemaView discriminator should correctly render SchemaView 
                   ],
                 },
               },
+              "readOnly": undefined,
               "required": Array [
                 "type",
               ],
               "title": "Dog",
               "type": "object",
+              "writeOnly": undefined,
               "x-circular-ref": undefined,
               "x-parentRefs": Array [
                 "#/components/schemas/Pet",
@@ -1699,6 +1702,7 @@ exports[`Components SchemaView discriminator should correctly render SchemaView 
             ],
             "schema": Object {
               "allOf": undefined,
+              "description": undefined,
               "discriminator": Object {
                 "propertyName": "type",
               },
@@ -1717,11 +1721,13 @@ exports[`Components SchemaView discriminator should correctly render SchemaView 
                   ],
                 },
               },
+              "readOnly": undefined,
               "required": Array [
                 "type",
               ],
               "title": "Cat",
               "type": "object",
+              "writeOnly": undefined,
               "x-circular-ref": undefined,
               "x-parentRefs": Array [
                 "#/components/schemas/Pet",
@@ -2811,6 +2817,7 @@ exports[`Components SchemaView discriminator should correctly render SchemaView 
       ],
       "schema": Object {
         "allOf": undefined,
+        "description": undefined,
         "discriminator": Object {
           "propertyName": "type",
         },
@@ -2826,11 +2833,13 @@ exports[`Components SchemaView discriminator should correctly render SchemaView 
             ],
           },
         },
+        "readOnly": undefined,
         "required": Array [
           "type",
         ],
         "title": "Dog",
         "type": "object",
+        "writeOnly": undefined,
         "x-circular-ref": undefined,
         "x-parentRefs": Array [
           "#/components/schemas/Pet",

--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -217,6 +217,9 @@ export class OpenAPIParser {
         items,
         required,
         title,
+        description,
+        readOnly,
+        writeOnly,
         oneOf,
         anyOf,
         'x-circular-ref': isCircular,
@@ -305,6 +308,9 @@ export class OpenAPIParser {
       receiver = {
         ...receiver,
         title: receiver.title || title,
+        description: receiver.description || description,
+        readOnly: receiver.readOnly !== undefined ? receiver.readOnly : readOnly,
+        writeOnly: receiver.writeOnly !== undefined ? receiver.writeOnly : writeOnly,
         'x-circular-ref': receiver['x-circular-ref'] || isCircular,
         ...otherConstraints,
       };

--- a/src/services/__tests__/models/RequestBody.test.ts
+++ b/src/services/__tests__/models/RequestBody.test.ts
@@ -1,3 +1,5 @@
+import { parseYaml } from '@redocly/openapi-core';
+import { outdent } from 'outdent';
 import { RequestBodyModel } from '../../models/RequestBody';
 import { OpenAPIParser } from '../../OpenAPIParser';
 import { RedocNormalizedOptions } from '../../RedocNormalizedOptions';
@@ -22,6 +24,56 @@ describe('Models', () => {
       const req = new RequestBodyModel(props);
       expect(consoleError).not.toHaveBeenCalled();
       expect(req).toEqual({ description: '', required: false });
+    });
+
+    test('should have correct field data when it includes allOf', () => {
+      const spec = parseYaml(outdent`
+          openapi: 3.0.0
+          paths:
+            /user:
+              post:
+                tags:
+                  - user
+                summary: Create user
+                description: This can only be done by the logged in user.
+                operationId: createUser
+                requestBody:
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/User'
+                  description: Created user object
+                  required: true
+          components:
+            schemas:
+              User:
+                allOf:
+                  - type: object
+                    properties:
+                      name:
+                        type: string
+                        description: correct description name
+                        readOnly: false
+                        writeOnly: false
+                        allOf:
+                          - $ref: '#/components/schemas/NameField'
+              NameField:
+                description: name description
+                readOnly: true
+                writeOnly: true
+          `) as any;
+
+      parser = new OpenAPIParser(spec, undefined, opts);
+      const req = new RequestBodyModel({
+        parser,
+        infoOrRef: spec.paths['/user'].post.requestBody,
+        options: opts,
+        isEvent: false,
+      });
+      const nameField = req.content?.mediaTypes[0].schema?.fields?.[0];
+      expect(nameField?.schema.readOnly).toBe(false);
+      expect(nameField?.schema.writeOnly).toBe(false);
+      expect(nameField?.description).toMatchInlineSnapshot(`"correct description name"`);
     });
   });
 });

--- a/src/services/__tests__/models/__snapshots__/Schema.test.ts.snap
+++ b/src/services/__tests__/models/__snapshots__/Schema.test.ts.snap
@@ -4,18 +4,24 @@ exports[`Models Schema schemaDefinition should resolve field with conditional op
 Object {
   "allOf": undefined,
   "default": undefined,
+  "description": undefined,
   "items": Object {
     "allOf": undefined,
+    "description": undefined,
     "format": "url",
+    "readOnly": undefined,
     "title": undefined,
     "type": "string",
+    "writeOnly": undefined,
     "x-circular-ref": undefined,
     "x-parentRefs": Array [],
   },
   "maxItems": 20,
   "minItems": 1,
+  "readOnly": undefined,
   "title": "isString",
   "type": "string",
+  "writeOnly": undefined,
   "x-circular-ref": undefined,
   "x-displayName": "isString",
   "x-parentRefs": Array [],
@@ -26,23 +32,29 @@ exports[`Models Schema schemaDefinition should resolve field with conditional op
 Object {
   "allOf": undefined,
   "default": undefined,
+  "description": undefined,
   "items": Object {
     "allOf": undefined,
+    "description": undefined,
     "format": "url",
+    "readOnly": undefined,
     "title": undefined,
     "type": "string",
+    "writeOnly": undefined,
     "x-circular-ref": undefined,
     "x-parentRefs": Array [],
   },
   "maxItems": 10,
   "minItems": 1,
   "pattern": "\\\\d+",
+  "readOnly": undefined,
   "title": "notString",
   "type": Array [
     "string",
     "integer",
     "null",
   ],
+  "writeOnly": undefined,
   "x-circular-ref": undefined,
   "x-displayName": "notString",
   "x-parentRefs": Array [],
@@ -52,6 +64,7 @@ Object {
 exports[`Models Schema schemaDefinition should resolve schema with conditional operators 1`] = `
 Object {
   "allOf": undefined,
+  "description": undefined,
   "maxItems": 2,
   "properties": Object {
     "test": Object {
@@ -62,20 +75,25 @@ Object {
       ],
       "items": Object {
         "allOf": undefined,
+        "description": undefined,
         "format": "url",
+        "readOnly": undefined,
         "title": undefined,
         "type": "string",
+        "writeOnly": undefined,
         "x-circular-ref": undefined,
         "x-parentRefs": Array [],
       },
       "maxItems": 20,
       "minItems": 1,
+      "readOnly": undefined,
       "title": undefined,
       "type": Array [
         "string",
         "integer",
         "null",
       ],
+      "writeOnly": undefined,
       "x-circular-ref": undefined,
       "x-parentRefs": Array [],
       "x-refsStack": Array [
@@ -83,8 +101,10 @@ Object {
       ],
     },
   },
+  "readOnly": undefined,
   "title": "=== 10",
   "type": "object",
+  "writeOnly": undefined,
   "x-circular-ref": undefined,
   "x-parentRefs": Array [],
 }
@@ -93,6 +113,7 @@ Object {
 exports[`Models Schema schemaDefinition should resolve schema with conditional operators 2`] = `
 Object {
   "allOf": undefined,
+  "description": undefined,
   "maxItems": 20,
   "properties": Object {
     "test": Object {
@@ -113,8 +134,10 @@ Object {
       ],
     },
   },
+  "readOnly": undefined,
   "title": "case 2",
   "type": "object",
+  "writeOnly": undefined,
   "x-circular-ref": undefined,
   "x-parentRefs": Array [],
 }


### PR DESCRIPTION
## What/Why/How?
fix: https://github.com/Redocly/redoc/issues/2079

## Reference

## Testing
```yaml
openapi: 3.0.3
info:
  version: 0.0.1
  title: Test API
servers: []
tags:
  - name: Order
paths:
  /orders:
    summary: Product ordering
    post:
      tags:
        - Order
      summary: Create order
      description: |
        Create an order
      operationId: createProductOrder
      requestBody:
        $ref: "#/components/requestBodies/Order"
      responses:
        "201":
          $ref: "#/components/responses/OrderCreated"
components:
  schemas:
    ProductOfferingId:
      description: Original description for type `ProductOfferingId` which should have
        been overridden
      type: string
      example: SOME_PRODUCT
    AccountId:
      description: >
        Original description for type `AccountId` which should have been
        overridden (type with `readOnly: true`)
      type: string
      readOnly: true
      example: "123456789"
    ProductOrder:
      description: |
        Represents an order
      type: object
      properties:
        offeringId:
          description: |
            Overidden description for `offeringId`
          allOf:
            - $ref: "#/components/schemas/ProductOfferingId"
        billingAccountId:
          description: >
            Overridden description for `billingAccountId` (type with `readOnly:
            false`)
          readOnly: false
          allOf:
            - $ref: "#/components/schemas/AccountId"
  requestBodies:
    Order:
      required: true
      content:
        application/json:
          schema:
            $ref: "#/components/schemas/ProductOrder"
  responses:
    OrderCreated:
      description: Created
      content:
        application/json:
          schema:
            $ref: "#/components/schemas/ProductOrder"
```
## Screenshots (optional)
<img width="864" alt="Screenshot 2022-07-18 at 18 54 08" src="https://user-images.githubusercontent.com/14113673/179551899-9aaa70d7-33f6-4b50-a1db-f5be2cdf900a.png">

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
