### PR TITLE
Fixing 404 on the documentation page

### DIFF
--- a/docs/deployment/react.md
+++ b/docs/deployment/react.md
@@ -59,7 +59,7 @@ For example:
 ```
 
 For more information on configuration options, refer to the
-[Configuration options for Reference docs](https://redocly.com/docs/api-reference-docs/configuration/)
+[Configuration options for Reference docs](https://redocly.com/docs/api-reference-docs/configuration/functionality/)
 section of the documentation. Options available for Redoc are noted,
 "Supported in Redoc CE".
 


### PR DESCRIPTION
## What/Why/How?
Currently getting a 404 when hitting this link on the deployed site

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ X] Code is linted
- [X ] Tested
- [X ] All new/updated code is covered with tests
