### PR TITLE
chore: improve deprecation message in serve command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -14,7 +14,7 @@ The two following commands are available:
 - `redoc-cli serve [spec]` - starts the server with `spec` rendered with ReDoc.
   Supports a server-side rendering mode (`--ssr`)
   and can watch the spec (`--watch`) to automatically reload the page whenever it changes.\
-  Deprecated. Use `npx @redocly/openapi-cli preview-docs [spec]`
+  Deprecated. Use `npx @redocly/cli preview-docs [spec]`
 - `redoc-cli bundle [spec]` - bundles `spec` and Redoc into a **zero-dependency** HTML file.\
   Deprecated. Use Use "build" command instead.
 - `redoc-cli build [spec]` - build `spec` and Redoc into a **zero-dependency** HTML file.

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -182,7 +182,7 @@ YargsParser.command(
   [
     res => {
       console.log(
-        `\n⚠️ This command is deprecated. Use "npx @redocly/openapi-cli preview-docs petstore.yaml"\n`,
+        `\n⚠️ This command is deprecated. Use "npx @redocly/cli preview-docs petstore.yaml"\n`,
       );
       return res;
     },


### PR DESCRIPTION
## What/Why/How?
`@redocly/openapi-cli` renamed to `@redocly/cli`. We improve the deprecation message about that.
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
