### PR TITLE
fix: invalid url when href is empty

### DIFF
--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -35,7 +35,7 @@ export class OpenAPIParser {
 
     const href = IS_BROWSER ? window.location.href : '';
     if (typeof specUrl === 'string') {
-      this.specUrl = new URL(specUrl, href).href;
+      this.specUrl = href ? new URL(specUrl, href).href : specUrl;
     }
   }
 


### PR DESCRIPTION
## What/Why/How?
we have an error with an invalid URL and fail tests. 
<img width="1184" alt="Screenshot 2022-07-28 at 15 41 59" src="https://user-images.githubusercontent.com/14113673/181507590-ba36c231-9ef4-4baf-9021-85768e571c6d.png">
https://github.com/Redocly/redoc/runs/7559970321?check_suite_focus=true

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
