### PR TITLE
fix: sibling for openapi 3.1

### DIFF
--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -132,11 +132,21 @@ export class OpenAPIParser {
     if (
       mergeAsAllOf &&
       keys.some(
-        k => !['description', 'title', 'externalDocs', 'x-refsStack', 'x-parentRefs'].includes(k),
+        k =>
+          ![
+            'description',
+            'title',
+            'externalDocs',
+            'x-refsStack',
+            'x-parentRefs',
+            'readOnly',
+            'writeOnly',
+          ].includes(k),
       )
     ) {
+      const { description, title, readOnly, writeOnly, ...restSchema } = rest as OpenAPISchema;
       return {
-        allOf: [resolved, rest],
+        allOf: [{ description, title, readOnly, writeOnly }, resolved, restSchema],
       } as T;
     } else {
       // small optimization

--- a/src/services/__tests__/models/Response.test.ts
+++ b/src/services/__tests__/models/Response.test.ts
@@ -1,3 +1,6 @@
+import { parseYaml } from '@redocly/openapi-core';
+import { outdent } from 'outdent';
+
 import { ResponseModel } from '../../models/Response';
 import { OpenAPIParser } from '../../OpenAPIParser';
 import { RedocNormalizedOptions } from '../../RedocNormalizedOptions';
@@ -52,6 +55,82 @@ describe('Models', () => {
       });
       expect(Object.keys(resp.extensions).length).toEqual(1);
       expect(resp.extensions['x-example']).toEqual({ a: 1 });
+    });
+
+    test('should get correct sibling in responses for openapi 3.1', () => {
+      const spec = parseYaml(outdent`
+        openapi: 3.1.0
+        paths:
+          /test:
+            get:
+              operationId: test
+              responses:
+                '200':
+                  description: Overridden description
+                  $ref: "#/components/responses/Successful"
+        components:
+          responses:
+            Successful:
+              description: successful operation
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      successful:
+                        type: boolean
+      `) as any;
+
+      parser = new OpenAPIParser(spec, undefined, opts);
+      const code = '200';
+      const responseModel = new ResponseModel({
+        parser: parser,
+        code: code,
+        defaultAsError: false,
+        infoOrRef: spec.paths['/test'].get.responses[code],
+        options: opts,
+        isEvent: false,
+      });
+
+      expect(responseModel.summary).toBe('Overridden description');
+    });
+
+    test('should not override description in responses for openapi 3.0', () => {
+      const spec = parseYaml(outdent`
+        openapi: 3.0.0
+        paths:
+          /test:
+            get:
+              operationId: test
+              responses:
+                '200':
+                  description: Overridden description
+                  $ref: "#/components/responses/Successful"
+        components:
+          responses:
+            Successful:
+              description: successful operation
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      successful:
+                        type: boolean
+      `) as any;
+
+      parser = new OpenAPIParser(spec, undefined, opts);
+      const code = '200';
+      const responseModel = new ResponseModel({
+        parser: parser,
+        code: code,
+        defaultAsError: false,
+        infoOrRef: spec.paths['/test'].get.responses[code],
+        options: opts,
+        isEvent: false,
+      });
+
+      expect(responseModel.summary).toBe('successful operation');
     });
   });
 });


### PR DESCRIPTION
## What/Why/How?
fixes: https://github.com/Redocly/redoc/issues/2042
Seems it is broken when we override recursive check logic.

```json
{
      "openapi": "3.1.0",
      "info": {
        "title": "AA",
        "version": "1.0"
      },
      "paths": {
        "/test": {
          "get": {
            "operationId": "test",
            "responses": {
              "200": {
                "content": {
                  "application/json": {
                    "schema": {
                      "type": "object",
                      "properties": {
                        "testAttr": {
                          "description": "Overriden description",
                          "$ref": "#/components/schemas/Test"
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        },
      },
      "components": {
        "schemas": {
          "Test": {
            "type": "object",
            "description": "Refed description"
          }
        }
      }
    }
  ```
## Reference

## Testing

## Screenshots (optional)
<img width="890" alt="Screenshot 2022-08-01 at 17 56 55" src="https://user-images.githubusercontent.com/14113673/182178494-ecc91cc7-0ea1-4ba3-b1d9-10340cd4f1ba.png">

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
