### PR TITLE
fix: problem in rc-74

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "mobx-react": "^7.2.0",
         "openapi-sampler": "^1.3.0",
         "path-browserify": "^1.0.1",
-        "perfect-scrollbar": "^1.5.1",
+        "perfect-scrollbar": "^1.5.5",
         "polished": "^4.1.3",
         "prismjs": "^1.27.0",
         "prop-types": "^15.7.2",
@@ -14581,9 +14581,9 @@
       "dev": true
     },
     "node_modules/perfect-scrollbar": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.1.tgz",
-      "integrity": "sha512-MrSImINnIh3Tm1hdPT6bji6fmIeRorVEegQvyUnhqko2hDGTHhmjPefHXfxG/Jb8xVbfCwgmUIlIajERGXjVXQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz",
+      "integrity": "sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g=="
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -30249,9 +30249,9 @@
       "dev": true
     },
     "perfect-scrollbar": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.1.tgz",
-      "integrity": "sha512-MrSImINnIh3Tm1hdPT6bji6fmIeRorVEegQvyUnhqko2hDGTHhmjPefHXfxG/Jb8xVbfCwgmUIlIajERGXjVXQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz",
+      "integrity": "sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g=="
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "ts-jest": "^27.0.2",
         "ts-loader": "^9.2.6",
         "ts-node": "^10.0.0",
+        "tslib": "^2.4.0",
         "typescript": "~4.1.0",
         "unfetch": "^4.2.0",
         "webpack": "^5.50.1",
@@ -17839,9 +17840,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -32762,9 +32763,9 @@
       }
     },
     "tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "tsutils": {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "mobx-react": "^7.2.0",
     "openapi-sampler": "^1.3.0",
     "path-browserify": "^1.0.1",
-    "perfect-scrollbar": "^1.5.1",
+    "perfect-scrollbar": "^1.5.5",
     "polished": "^4.1.3",
     "prismjs": "^1.27.0",
     "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "ts-jest": "^27.0.2",
     "ts-loader": "^9.2.6",
     "ts-node": "^10.0.0",
+    "tslib": "^2.4.0",
     "typescript": "~4.1.0",
     "unfetch": "^4.2.0",
     "webpack": "^5.50.1",

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -132,12 +132,13 @@ export class SearchBox extends React.PureComponent<SearchBoxProps, SearchBoxStat
 
   render() {
     const { activeItemIdx } = this.state;
-    const results = this.state.results.map(res => ({
-      item: this.props.getItemById(res.meta)!,
-      score: res.score,
-    }));
-
-    results.sort((a, b) => b.score - a.score);
+    const results = this.state.results
+      .filter(res => this.props.getItemById(res.meta))
+      .map(res => ({
+        item: this.props.getItemById(res.meta)!,
+        score: res.score,
+      }))
+      .sort((a, b) => b.score - a.score);
 
     return (
       <SearchWrap role="search">

--- a/src/services/models/Schema.ts
+++ b/src/services/models/Schema.ts
@@ -254,10 +254,10 @@ export class SchemaModel {
           title,
           allOf: [{ ...this.schema, oneOf: undefined, anyOf: undefined }],
         } as OpenAPISchema,
-        this.pointer + '/oneOf/' + idx,
+        variant.$ref || this.pointer + '/oneOf/' + idx,
         this.options,
         false,
-        this.refsStack,
+        refsStack,
       );
 
       return schema;


### PR DESCRIPTION
## What/Why/How?
fixes https://github.com/Redocly/redoc/issues/2114
fixes https://github.com/Redocly/redoc/issues/2107
fixes https://github.com/Redocly/redoc/issues/2122

## Reference

## Testing

[openEO.json.zip](https://github.com/Redocly/redoc/files/9251150/openEO.json.zip)

```yaml
openapi: 3.1.0
info:
  version: 1.0.0
  title: Swagger Petstore
  summary: My lovely API
  termsOfService: 'http://swagger.io/terms/'
tags:
  - name: pet
    description: Everything about your Pets
  - name: store
    description: Access to Petstore orders
  - name: user
    description: Operations about user
  - name: webhooks
    description: Everything about your Webhooks
  - name: store_model
    x-displayName: The Order Model
    description: |
      <SchemaDefinition schemaRef="#/components/schemas/Order" exampleRef="#/components/examples/Order" showReadOnly={true} showWriteOnly={true} />
paths:
  /user:
    post:
      tags:
        - user
      summary: Create user
      description: This can only be done by the logged in user.
      operationId: createUser
      responses:
        default:
          description: successful operation
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/User'
        description: Created user object
        required: true
components:
  schemas:
    Tag:
      type: object
      properties:
        name:
          description: Tag name
          type: string
          minLength: 1
        items:
          description: kuku
          oneOf:
            # - type: boolean
            - type: array
              items:
                $ref: "#/components/schemas/Tag"
            - $ref: "#/components/schemas/Tag"
      xml:
        name: Tag
    User:
      type: object
      properties:
        pet:
          oneOf:
            - $ref: '#/components/schemas/Tag'
  securitySchemes:
    petstore_auth:
      description: |
        Get access to data while protecting your account credentials.
        OAuth2 is also a safer and more secure way to give you access.
      type: oauth2
      flows:
        implicit:
          authorizationUrl: 'http://petstore.swagger.io/api/oauth/dialog'
          scopes:
            'write:pets': modify pets in your account
            'read:pets': read your pets
    api_key:
      description: >
        For this sample, you can use the api key `special-key` to test the
        authorization filters.
      type: apiKey
      name: api_key
      in: header

```

## Screenshots (optional)
**#2114**
<img width="1788" alt="Screenshot 2022-08-03 at 15 10 23" src="https://user-images.githubusercontent.com/14113673/182604440-41dab625-5709-4d58-8e45-f49feb9a0068.png">
<img width="852" alt="Screenshot 2022-08-10 at 11 32 17" src="https://user-images.githubusercontent.com/14113673/183854578-e9a07327-861a-4c2b-a0ae-e7d3e940c3d7.png">

**#2122**
<img width="333" alt="Screenshot 2022-08-10 at 11 33 33" src="https://user-images.githubusercontent.com/14113673/183855117-cc3682af-5269-4f9d-b732-a9fe82c0d91f.png">

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
