### PR TITLE
fix missing update-notifier issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "stickyfill": "^1.1.1",
     "style-loader": "^3.3.1",
     "swagger2openapi": "^7.0.6",
+    "update-notifier": "^6.0.2",
     "url-template": "^2.0.8"
   },
   "size-limit": [


### PR DESCRIPTION
## What/Why/How?
build fail due to missing `update-notifier` in package.json.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
