### PR TITLE
chore: add install cli to publish actions

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -21,7 +21,7 @@ jobs:
           restore-keys: |
             npm-${{ hashFiles('package-lock.json') }}
             npm-
-      - run: npm ci
+      - run: npm ci && npm ci --prefix cli
       - run: npm run bundle
       - name: Store bundle artifact
         uses: actions/upload-artifact@v3
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: npm ci
+      - run: npm ci && npm ci --prefix cli
       - name: Download bundled artifact
         uses: actions/download-artifact@v3
         with:
@@ -65,7 +65,7 @@ jobs:
             npm-${{ hashFiles('package-lock.json') }}
             npm-
       - name: Install dependencies
-        run: npm ci
+        run: npm ci && npm ci --prefix cli
       - name: Bundle
         run: npm run compile:cli
       - name: Store bundle artifact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           restore-keys: |
             npm-${{ hashFiles('package-lock.json') }}
             npm-
-      - run: npm ci
+      - run: npm ci && npm ci --prefix cli
       - run: npm run bundle
       - name: Store bundle artifact
         uses: actions/upload-artifact@v3
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: npm ci
+      - run: npm ci npm ci --prefix cli
       - name: Download bundled artifact
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
## What/Why/How?
we should also make install `cli` in publish script.
related to https://github.com/Redocly/redoc/runs/7766686742?check_suite_focus=true
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
