### PR TITLE
fix: encoding issue in CDN responses

### DIFF
--- a/scripts/publish-cdn.sh
+++ b/scripts/publish-cdn.sh
@@ -8,7 +8,9 @@ VERSION=$(node scripts/version.js)
 VERSION_TAG=v${VERSION:0:1}.x
 
 copy_to_s3 () {
-  aws s3 cp bundles "s3://redocly-cdn/redoc/$1/bundles" --recursive
+  aws s3 cp --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8" bundles "s3://redocly-cdn/redoc/$1/bundles" --recursive
+  aws s3 cp --exclude "*" --include "*.map" --content-type "application/json" bundles "s3://redocly-cdn/redoc/$1/bundles" --recursive
+  aws s3 cp --exclude "*" --include "*.txt" bundles "s3://redocly-cdn/redoc/$1/bundles" --recursive
   aws s3 cp CHANGELOG.md "s3://redocly-cdn/redoc/$1/CHANGELOG.md"
   aws s3 cp LICENSE "s3://redocly-cdn/redoc/$1/LICENSE"
   aws s3 cp package.json "s3://redocly-cdn/redoc/$1/package.json"


### PR DESCRIPTION
## What/Why/How?

When downloading the redoc JS from redoc.ly CDN (e.g. https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js) the `Content-Type` header in the response is missing `'charset=utf-8'`, causing the file to be displayed with garbled characters.

I faced the issue in my project and found that it was indirectly reported multiple times over the years, as can be seen in https://github.com/Redocly/redoc/issues/29.

The solution proposed in https://github.com/Redocly/redoc/issues/213#issuecomment-282761418 is just a workaround and I'm actually not sure why it works for other people because according to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-charset, "UTF-8 is the only valid encoding for HTML5 documents" anyway.

## Reference

- `aws-cli` doesn't automatically detect the charset when uploading files https://github.com/aws/aws-cli/issues/1346
- there was also a similar issue opened at https://github.com/jsdelivr/bootstrapcdn/issues/949

## Testing

Open the above URL in a browser and search for e.g. `.ellipsis:after`. The value of `content` should be displayed as 
![image](https://user-images.githubusercontent.com/2833843/184130116-77110fc2-0eb0-452b-af70-4db46e5cc931.png)
instead of
![image](https://user-images.githubusercontent.com/2833843/184129991-7c1a8146-2387-4db2-b8bd-faff2671900b.png)
