### PR TITLE
fix: "API Docs By Redocly" overlapping last element in sidebar

### DIFF
--- a/src/components/SideMenu/styled.elements.ts
+++ b/src/components/SideMenu/styled.elements.ts
@@ -84,6 +84,10 @@ export const MenuItemUl = styled.ul<{ expanded: boolean }>`
   margin: 0;
   padding: 0;
 
+  &:first-child {
+    padding-bottom: 32px;
+  }
+
   & & {
     font-size: 0.929em;
   }
@@ -169,27 +173,27 @@ export const MenuItemTitle = styled.span<{ width?: string }>`
 `;
 
 export const RedocAttribution = styled.div`
-  ${({ theme }) => `
-  font-size: 0.8em;
-  margin-top: ${theme.spacing.unit * 2}px;
-  text-align: center;
-  position: fixed;
-  width: ${theme.sidebar.width};
-  bottom: 0px;
-  background: ${theme.sidebar.backgroundColor};
- 
-  a,
-  a:visited,
-  a:hover {
-    color: ${theme.sidebar.textColor} !important;
-    padding: ${theme.spacing.unit}px 0;
-    border-top: 1px solid ${darken(0.1, theme.sidebar.backgroundColor)};
-    text-decoration: none;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-`};
+  ${({ theme }) => css`
+    font-size: 0.8em;
+    margin-top: ${theme.spacing.unit * 2}px;
+    text-align: center;
+    position: fixed;
+    width: ${theme.sidebar.width};
+    bottom: 0;
+    background: ${theme.sidebar.backgroundColor};
+
+    a,
+    a:visited,
+    a:hover {
+      color: ${theme.sidebar.textColor} !important;
+      padding: ${theme.spacing.unit}px 0;
+      border-top: 1px solid ${darken(0.1, theme.sidebar.backgroundColor)};
+      text-decoration: none;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  `};
   img {
     width: 15px;
     margin-right: 5px;


### PR DESCRIPTION
## What/Why/How?
fix: "API Docs By Redocly" overlapping last element in sidebar
## Reference

## Testing

## Screenshots (optional)
`Before`
<img width="526" alt="image" src="https://user-images.githubusercontent.com/26272493/184909187-fedb19d1-5d78-4cc2-8480-d27c6428ca29.png">

`After`
<img width="358" alt="image" src="https://user-images.githubusercontent.com/26272493/184909375-81152074-7061-4f56-a470-4cae66e8ec2c.png">

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
