### PR TITLE
fix: Optional authentication not rendered properly (#2117)

### DIFF
--- a/src/components/SecurityRequirement/SecurityHeader.tsx
+++ b/src/components/SecurityRequirement/SecurityHeader.tsx
@@ -17,6 +17,8 @@ export function SecurityHeader(props: SecurityRequirementProps) {
   const { security, showSecuritySchemeType, expanded } = props;
 
   const grouping = security.schemes.length > 1;
+  if (security.schemes.length === 0)
+    return <SecurityRequirementOrWrap expanded={expanded}>None</SecurityRequirementOrWrap>;
   return (
     <SecurityRequirementOrWrap expanded={expanded}>
       {grouping && '('}

--- a/src/components/__tests__/SecurityRequirement.test.tsx
+++ b/src/components/__tests__/SecurityRequirement.test.tsx
@@ -9,6 +9,7 @@ import {
   SecuritySchemesModel,
 } from '../../services';
 import { StoreProvider } from '../StoreBuilder';
+import { SecurityRequirementModel } from '../../services/models/SecurityRequirement';
 import { SecurityRequirements } from '../SecurityRequirement/SecurityRequirement';
 import { withTheme } from '../testProviders';
 import { SecurityDefs } from '../SecuritySchemes/SecuritySchemes';
@@ -48,6 +49,20 @@ describe('SecurityRequirement', () => {
       withTheme(<SecurityDefs securitySchemes={new SecuritySchemesModel(parser)} />),
     );
     expect(component.html()).toMatchSnapshot();
+  });
+
+  it("should render 'None' when empty object in security open api", () => {
+    const options = new RedocNormalizedOptions({});
+    const parser = new OpenAPIParser(
+      { openapi: '3.0', info: { title: 'test', version: '0' }, paths: {} },
+      undefined,
+      options,
+    );
+    const securityRequirement = [new SecurityRequirementModel({}, parser)];
+    const component = mount(
+      withTheme(<SecurityRequirements securities={securityRequirement} key={1} />),
+    );
+    expect(component.find('span').at(0).text()).toEqual('None');
   });
 
   it('should hide authDefinition', async () => {


### PR DESCRIPTION
## What/Why/How?
Representing optional authentication on endpoint don't display properly.
![image](https://user-images.githubusercontent.com/12560152/185004286-e0e5c65a-2fc0-423f-b096-ec0fd0e4c8c3.png)
![image](https://user-images.githubusercontent.com/12560152/185004291-23deafc5-e9f6-4143-be33-0f842ef07412.png)

After fix 

```
security:
  - {}
  - basic: []

```
or

```
security:
  - basic: []
  -  {}
```
Should be displayed properly

## Reference
https://github.com/Redocly/redoc/issues/2117

## Testing
Unit test added
for manual testing, modify openapi.yaml
```
      security:
        - api_key: []
```
to
```
      security:
        - {}
        - api_key: []

```
## Screenshots (optional)
![image](https://user-images.githubusercontent.com/12560152/185003726-e08a89c7-b81b-4302-bab9-87c31321007a.png)
![image](https://user-images.githubusercontent.com/12560152/185003735-acd545f6-133d-4b9a-9a6c-070c0c513acb.png)
![image](https://user-images.githubusercontent.com/12560152/185003750-6ff3d410-0eec-4080-9bcc-f0bd76838157.png)
![image](https://user-images.githubusercontent.com/12560152/185003757-c25e4ee8-0768-4c8e-b8f5-f9920a25ada9.png)
![image](https://user-images.githubusercontent.com/12560152/185003762-a06a1b0e-8804-4b26-b7a5-496da26bd655.png)
![image](https://user-images.githubusercontent.com/12560152/185003765-2ad56e20-9850-4fbd-a041-efe6d7c05aaf.png)
![image](https://user-images.githubusercontent.com/12560152/185003941-c6ad0e8a-491b-4bd8-acce-6c01ee9e182f.png)
![image](https://user-images.githubusercontent.com/12560152/185003950-b4a16a7f-7a7e-4a39-80b7-ab12d15e14cf.png)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
