### PR TITLE
fix: do not use discriminator when specific schema was referenced in oneOf or anyOf

### DIFF
--- a/src/services/models/Schema.ts
+++ b/src/services/models/Schema.ts
@@ -253,6 +253,8 @@ export class SchemaModel {
           ...merged,
           title,
           allOf: [{ ...this.schema, oneOf: undefined, anyOf: undefined }],
+          // if specific child schemas are listed in oneOf/anyOf, they are not supposed to be discriminated
+          discriminator: derefVariant.allOf ? undefined : merged.discriminator,
         } as OpenAPISchema,
         variant.$ref || this.pointer + '/oneOf/' + idx,
         this.options,


### PR DESCRIPTION
## What/Why/How?

When specific child schema is mentioned in anyOf or oneOf most likely it is meant to be the specific instance and not be discriminated. 

## Reference

Fixes https://github.com/Redocly/redoc/issues/2133

## Testing

Added a test.

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
