### PR TITLE
demo/index.tsx: Update to use new Redoc logo

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -94,7 +94,7 @@ class DemoApp extends React.Component<
         <Heading>
           <a href=".">
             <Logo
-              src="https://github.com/Redocly/redoc/raw/main/docs/images/redoc-logo.png"
+              src="https://github.com/Redocly/redoc/raw/main/docs/images/redoc.png"
               alt="Redoc logo"
             />
           </a>


### PR DESCRIPTION
Currently the demo at https://redocly.github.io/redoc/ still uses the old logo:

![image](https://user-images.githubusercontent.com/478237/190214902-32b18b25-8910-42c7-a268-64bf2d65be86.png)

This PR changes the demo code to use the new logo:

![Redoc logo](https://github.com/Redocly/redoc/raw/main/docs/images/redoc.png)

Related changes:
- commit c4564de324d78c86e4436cf7ee0aa5b8c63f48ca from PR #1748 (/cc @HCloward)
- PR #2166
- Probably more, but I didn't dig further into the git history :smile: