### PR TITLE
chore:fix README(Use 2.0.x instead of rc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Refer to the Redocly's documentation for more information on these products:
 
 ## Releases
 **Important:** all the 2.x releases are deployed to npm and can be used with Redocly-cdn:
-- particular release, for example, `v2.0.0-rc.70`: https://cdn.redoc.ly/redoc/v2.0.0-rc.70/bundles/redoc.standalone.js
+- particular release, for example, `v2.0.0`: https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js
 - `latest` release: https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js
 
 Additionally, all the 1.x releases are hosted on our GitHub Pages-based CDN **(deprecated)**:
@@ -114,6 +114,7 @@ Additionally, all the 1.x releases are hosted on our GitHub Pages-based CDN **(d
 ## Version Guidance
 | Redoc Release | OpenAPI Specification |
 |:--------------|:----------------------|
+| 2.0.x         | 3.1, 3.0.x, 2.0       |
 | 2.0.0-alpha.54| 3.1, 3.0.x, 2.0       |
 | 2.0.0-alpha.x | 3.0, 2.0              |
 | 1.19.x        | 2.0                   |


### PR DESCRIPTION
## What/Why/How?

- [redoc 2.0.0 now GA.](https://github.com/Redocly/redoc/releases/tag/v2.0.0)
- Use 2.0.x instead of rc.

## Reference

- follow-up #2160

## Testing

## Screenshots (optional)

- Yes

![image](https://user-images.githubusercontent.com/10738333/190844901-7270346e-e626-4c28-932e-30b684746bab.png)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
