### PR TITLE
guard against nullables

### DIFF
--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -171,7 +171,7 @@ export class OpenAPIParser {
     $ref: string | undefined,
     refsStack: string[],
   ): MergedOpenAPISchema {
-    if (schema['x-circular-ref']) {
+    if (schema?.hasOwnProperty('x-circular-ref')) {
       return schema;
     }
 

--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -177,7 +177,7 @@ export class OpenAPIParser {
 
     schema = this.hoistOneOfs(schema, refsStack);
 
-    if (schema.allOf === undefined) {
+    if (schema.allOf === null || schema.allOf === undefined) {
       return schema;
     }
 
@@ -358,7 +358,7 @@ export class OpenAPIParser {
   }
 
   private hoistOneOfs(schema: OpenAPISchema, refsStack: string[]) {
-    if (schema.allOf === undefined) {
+    if (schema.allOf === null || schema.allOf === undefined) {
       return schema;
     }
 


### PR DESCRIPTION
## What/Why/How?
Running Redoc on Safari macOS, latest version of edge, or older version of Chrome triggers a an error: 
- "Cannot read properties of null(reading 'allOf')"
- "Cannot read properties of null(reading 'x-circular-ref')"

## Testing
This can be reproduced when opening redoc for the first time with older versions of chrome (for example https://filehippo.com/download_google-chrome/87.0.4280.66/post_download/) or latest version of edge or safari (macos)
However, after a refresh the error disappears. It only happens once when a user opens redoc for the first time.

## StackTraces

`TypeError: Cannot read properties of null (reading 'x-circular-ref')
    at fc.mergeAllOf (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:56216)
    at https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:63075
    at Array.map (<anonymous>)
    at Sc.initOneOf (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:62999)
    at Sc.init (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:61442)
    at new Sc (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:59880)
    at new nu (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:77432)
    at https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:78906
    at Array.map (<anonymous>)
    at new au (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:78877)
    at new yu (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:80413)
    at https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:83946
    at Array.map (<anonymous>)
    at get responses (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:83938)
    at _u.get (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:39:9705)
    at https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:1654:1004
    at qs (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:498002)
    at El (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:482461)
    at Ol (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:482389)
    at _l (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:482252)
    at ml (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:479239)
    at https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:429060
    at t.unstable_runWithPriority (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:517125)
    at Wo (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:428837)
    at Ko (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:429005)
    at Yo (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:428940)
    at ul (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:476624)
    at $a (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:8:448434)
    at n (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:117:1047)
    at n.next (<anonymous>)
    at o (https://cdn.redoc.ly/redoc/v2.0.0/bundles/redoc.standalone.js:117:1116)`

## Screenshots (optional)

![3bd6f309-9b55-4e6e-93fb-a88bbbb86ea5](https://user-images.githubusercontent.com/7645736/192537060-cfc5cacb-2b0f-47c4-acdf-6a369eea4a03.png)
![image (2)](https://user-images.githubusercontent.com/7645736/192543387-54a67901-1e7f-4f9c-bf48-7c6666ce1dd4.png)
![edge](https://user-images.githubusercontent.com/7645736/192736501-0a743e98-9700-4a42-ba27-74f27ebeb76b.png)