### PR TITLE
Remove GenericObject shim

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -23,5 +23,3 @@ declare var reactHotLoaderGlobal: any;
 interface Element {
   scrollIntoViewIfNeeded(centerIfNeeded?: boolean): void;
 }
-
-type GenericObject = Record<string, any>;

--- a/src/components/DropdownOrLabel/DropdownOrLabel.tsx
+++ b/src/components/DropdownOrLabel/DropdownOrLabel.tsx
@@ -4,7 +4,7 @@ import { StyledComponent } from 'styled-components';
 import { DropdownProps, MimeLabel, SimpleDropdown } from '../../common-elements/Dropdown';
 
 export interface DropdownOrLabelProps extends DropdownProps {
-  Label?: StyledComponent<any, any, GenericObject, never>;
+  Label?: StyledComponent<any, any, Record<string, any>, never>;
   Dropdown?: StyledComponent<
     React.NamedExoticComponent<DropdownProps>,
     any,

--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -41,7 +41,7 @@ export class OpenAPIParser {
     }
   }
 
-  validate(spec: GenericObject): void {
+  validate(spec: Record<string, any>): void {
     if (spec.openapi === undefined) {
       throw new Error('Document must be valid OpenAPI 3.0.0 definition');
     }
@@ -153,7 +153,7 @@ export class OpenAPIParser {
     } else {
       // small optimization
       return {
-        ...(resolved as GenericObject),
+        ...(resolved as object),
         ...rest,
       } as T;
     }

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,4 +1,4 @@
-export function objectHas(object: GenericObject, path: string | Array<string>): boolean {
+export function objectHas(object: object, path: string | Array<string>): boolean {
   let _path = <Array<string>>path;
 
   if (typeof path === 'string') {
@@ -12,7 +12,7 @@ export function objectHas(object: GenericObject, path: string | Array<string>): 
   });
 }
 
-export function objectSet(object: GenericObject, path: string | Array<string>, value: any): void {
+export function objectSet(object: object, path: string | Array<string>, value: any): void {
   let _path = <Array<string>>path;
 
   if (typeof path === 'string') {


### PR DESCRIPTION
This was declared in the local stubs file but not shipped, meaning that consumers with typescript libchecking enabled would have to also add the GenericObject definition to their local stubs file.

This commit inlines the definition where necessary, or replaces it with object where appropriate.

Fixes #2171

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
