### PR TITLE
chore: return genericObject for cli

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -23,3 +23,5 @@ declare var reactHotLoaderGlobal: any;
 interface Element {
   scrollIntoViewIfNeeded(centerIfNeeded?: boolean): void;
 }
+
+type GenericObject = Record<string, any>;


### PR DESCRIPTION
## What/Why/How?
return GenericObject for `redoc-cli`. We should remove it after releasing the next version of CLI.
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
