### PR TITLE
fix: call onLoaded if specs are not found

### DIFF
--- a/src/components/StoreBuilder.ts
+++ b/src/components/StoreBuilder.ts
@@ -48,6 +48,9 @@ export function StoreBuilder(props: StoreBuilderProps) {
         const resolved = await loadAndBundleSpec(spec || specUrl!);
         setResolvedSpec(resolved);
       } catch (e) {
+        if (onLoaded) {
+          onLoaded(e);
+        }
         setError(e);
         throw e;
       }


### PR DESCRIPTION
## What/Why/How?
fix: https://github.com/Redocly/redoc/issues/2025

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
