### PR TITLE
Prevent loss of field descriptions when converting swagger specs by using refSiblings: 'preserve'

### DIFF
--- a/src/services/__tests__/fixtures/2.0/complexFieldDescriptions.json
+++ b/src/services/__tests__/fixtures/2.0/complexFieldDescriptions.json
@@ -1,0 +1,65 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "AA",
+    "version": "1.0"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "test",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/components/schemas/Box"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Measurement": {
+      "type": "object",
+      "description": "Reusable measurement type.",
+      "properties": {
+        "value": {
+          "format": "double",
+          "description": "The numeric value of the measurement.",
+          "type": "number"
+        },
+        "uom": {
+          "description": "The unit-of-measurement.  \r\ne.g. kg, m³",
+          "type": "string"
+        }
+      }
+    },
+    "Box": {
+      "type": "object",
+      "description": "Model which contains a reused type as a field e.g. a box with dimensions.",
+      "properties": {
+        "weight": {
+          "$ref": "#/definitions/Measurement",
+          "description": "The gross weight of the box and its contents (in kg)."
+        },
+        "volume": {
+          "$ref": "#/definitions/Measurement",
+          "description": "The volume of the box (in m3)."
+        },
+        "height": {
+          "$ref": "#/definitions/Measurement",
+          "description": "The height of the box (in mm)."
+        },
+        "width": {
+          "$ref": "#/definitions/Measurement",
+          "description": "The width of the box (in mm)."
+        },
+        "depth": {
+          "$ref": "#/definitions/Measurement",
+          "description": "The depth of the box (in mm)."
+        }
+      }
+    }
+  }
+}

--- a/src/services/__tests__/models/FieldModel.test.ts
+++ b/src/services/__tests__/models/FieldModel.test.ts
@@ -1,6 +1,8 @@
 import { FieldModel } from '../../models/Field';
+import { SchemaModel } from '../../models';
 import { OpenAPIParser } from '../../OpenAPIParser';
 import { RedocNormalizedOptions } from '../../RedocNormalizedOptions';
+import { convertSwagger2OpenAPI } from '../../../utils/loadAndBundleSpec';
 
 const opts = new RedocNormalizedOptions({});
 
@@ -106,6 +108,54 @@ describe('Models', () => {
       );
 
       expect(field.name).toEqual('Test-Header');
+    });
+
+    test('field uses field description for complex objects', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const source = require('../fixtures/2.0/complexFieldDescriptions.json');
+
+      // check incoming source
+      expect(source.swagger).toEqual('2.0');
+
+      const spec = await convertSwagger2OpenAPI(source);
+
+      // sanity check for swagger 2.0 => 3.0
+      expect(spec?.openapi).toEqual('3.0.0');
+
+      const parser = new OpenAPIParser(spec, undefined, opts);
+      if (!spec.components?.schemas?.Box) {
+        throw Error('spec.components.schemas.Box is not a defined schema.');
+      }
+
+      const boxSchema = new SchemaModel(
+        parser,
+        spec.components.schemas.Box,
+        '#/components/schemas/Box',
+        opts,
+      );
+
+      if (!boxSchema.fields?.length) {
+        throw Error('No fields defined on the box schema.');
+      }
+
+      // expected on the measurement _type_ only.
+      const measurementSchemaDescription = 'Reusable measurement type.';
+
+      // expected on the weight _field_ only.
+      const weightField = boxSchema.fields[0];
+
+      expect(weightField.name).toBe('weight');
+      expect(weightField.description).toBe('The gross weight of the box and its contents (in kg).');
+
+      expect(weightField.schema.type).toBe('object');
+      expect(weightField.schema.title).toBe('Measurement');
+      expect(weightField.schema.description).toBe(measurementSchemaDescription);
+
+      // ensure all fields (they're all Measurements) don't inherit the schema's description.
+      for (const field of boxSchema.fields) {
+        expect(field.schema.title).toBe('Measurement');
+        expect(field.description).not.toBe(measurementSchemaDescription);
+      }
     });
   });
 });

--- a/src/utils/loadAndBundleSpec.ts
+++ b/src/utils/loadAndBundleSpec.ts
@@ -41,7 +41,7 @@ export async function loadAndBundleSpec(specUrlOrObject: object | string): Promi
 export function convertSwagger2OpenAPI(spec: any): Promise<OpenAPISpec> {
   console.warn('[ReDoc Compatibility mode]: Converting OpenAPI 2.0 to OpenAPI 3.0');
   return new Promise<OpenAPISpec>((resolve, reject) =>
-    convertObj(spec, { patch: true, warnOnly: true, text: '{}', anchors: true }, (err, res) => {
+    convertObj(spec, { patch: true, warnOnly: true, text: '{}', anchors: true, refSiblings: 'preserve' }, (err, res) => {
       // TODO: log any warnings
       if (err) {
         return reject(err);


### PR DESCRIPTION
This change resolves #2067 for converting swagger 2.0 based specs to open-api 3.0.0.

## What/Why/How?
Previously, when using a swagger 2.0 file with ReDoc, the descriptions of any field using a complex type (referencing another schema) would show the description of the _type_, instead of the description of the _field_ itself.

## Reference
As per https://github.com/Mermade/oas-kit/issues/597#issuecomment-1228344557, `swagger2openapi` needs `refSiblings: 'preserve'` to bring additional fields into the converted open-api object. 

This change makes the description field available to the `fieldSchema` objects, but _it also needs_ to be merged into the field model to be shown in the UI.

1. Alters call to `swagger2openapi` to use refSiblings: 'preserve'
2. Alters `models\Field.ts` when _deciding_ on the description value to use, now also considers the `fieldSchema.description` in addition to the existing info or schema description.
3. Adds a new test to `FieldModel.test.ts` and a new swagger 2.0 fixture `complexFieldDescriptions.json` for testing.

Additionally, there are two options for consideration when choosing the description:
1. Use the `fieldSchema.description` verbatim if it's defined, or
2. Concatenate the field description with the schema description. However, this option might be considered unintended behaviour.

I'll update (clean) the code depending on your thoughts.

## Screenshots
If you would reuse a type, say "Measurement", for both weight and volume fields, the intended description is lost i.e. see the repetitive description in the first screenshot:
![176603363-52afb20c-82dd-419f-a74f-30629e1e484c](https://user-images.githubusercontent.com/308188/202303395-f84b118b-82b4-4de5-b5c7-47462097a650.png)

where the _expected result_ is to show the explanation for the field:
![image](https://user-images.githubusercontent.com/308188/202303603-dff60e8c-2aba-4b93-83bd-17bae3e6b3fa.png)

## Checks

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

Final Notes:
- I did have some issues trying to get the vanilla _main_ branch to pass all tests before starting to make changes, so I've only focused on the tests applicable to this PR. I'm not sure if it's my local setup though...
- Some of the files in the base haven't had _prettier_ applied to them yet, so my changes to the `loadAndBundleSpec.ts` file would have had a lot of unrelated formatting changes to existing code. I opted out for that file only, so the diff is more representative of the change.
- I haven't created a lot of PRs before, so please let me know if I need to change/improve anything.