### PR TITLE
feat: add baseURL for redoc

### DIFF
--- a/src/services/AppStore.ts
+++ b/src/services/AppStore.ts
@@ -70,6 +70,10 @@ export class AppStore {
     // update position statically based on hash (in case of SSR)
     MenuStore.updateOnHistory(history.currentId, this.scroll);
 
+    if (options.baseURL) {
+      history.setBaseURL(options.baseURL);
+    }
+
     this.spec = new SpecStore(spec, specUrl, this.options);
     this.menu = new MenuStore(this.spec, this.scroll, history);
 

--- a/src/services/HistoryService.ts
+++ b/src/services/HistoryService.ts
@@ -6,10 +6,19 @@ const EVENT = 'hashchange';
 
 export class HistoryService {
   private _emiter;
+  private _baseURL: string | undefined;
 
   constructor() {
     this._emiter = new EventEmitter();
     this.bind();
+  }
+
+  setBaseURL(baseURL: string) {
+    this._baseURL = baseURL;
+  }
+
+  get baseURL(): string | undefined {
+    return this._baseURL;
   }
 
   get currentId(): string {
@@ -17,10 +26,15 @@ export class HistoryService {
   }
 
   linkForId(id: string) {
-    if (!id) {
-      return '';
+    const links: string[] = [];
+    if (this._baseURL) {
+      links.push(this._baseURL);
     }
-    return '#' + id;
+    if (id) {
+      links.push(id);
+    }
+    const link = links.join('/');
+    return link === '' ? '' : '#' + link;
   }
 
   subscribe(cb): () => void {

--- a/src/services/MenuStore.ts
+++ b/src/services/MenuStore.ts
@@ -123,6 +123,11 @@ export class MenuStore {
     }
     let item: IMenuItem | undefined;
 
+    const baseURL = this.history.baseURL;
+    if (baseURL && id.startsWith(baseURL + '/')) {
+      id = id.substring(baseURL.length + 1);
+    }
+
     item = this.flatItems.find(i => i.id === id);
 
     if (item) {

--- a/src/services/RedocNormalizedOptions.ts
+++ b/src/services/RedocNormalizedOptions.ts
@@ -56,6 +56,8 @@ export interface RedocRawOptions {
   hideFab?: boolean;
   minCharacterLengthToInitSearch?: number;
   showWebhookVerb?: boolean;
+
+  baseURL?: string;
 }
 
 export function argValueToBoolean(val?: string | boolean, defaultValue?: boolean): boolean {


### PR DESCRIPTION
## What/Why/How?

We have a requirement to embedded it inside one of our applications, but this application uses HashRouter. ReDoc will rewrite the URL, which leads to an unknown route. So add a url prefix for document. 

fix: https://github.com/Redocly/redoc/issues/447

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
