### PR TITLE
Improve accessible label by using the property name

### DIFF
--- a/src/components/Fields/Field.tsx
+++ b/src/components/Fields/Field.tsx
@@ -73,7 +73,7 @@ export class Field extends React.Component<FieldProps> {
         <button
           onClick={this.toggle}
           onKeyPress={this.handleKeyPress}
-          aria-label="expand properties"
+          aria-label={`expand ${name}`}
         >
           <span className="property-name">{name}</span>
           <ShelfIcon direction={expanded ? 'down' : 'right'} />


### PR DESCRIPTION
## What/Why/How?
Fixes #2223 

Summary: Labels and accessible labes should correspond. The use of `expand property` instead of `expand {name}` breaks this WCAG rule.

## Reference

## Testing
Testing the issue this PR resolves requires using SiteImprove or the [SiteImprove Chrome extension](https://chrome.google.com/webstore/detail/siteimprove-accessibility/djcglbmbegflehmbfleechkjhmedcopn?hl=en) 

AND it requires using another example than the PetStore as it for some reason crashes the extension.

I have tried outlining the issue i the issue and have tested that this change resolves the issue locally.

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested
- [x] All new/updated code is covered with tests

I'm not able to get this projects test running fully locally. Problems with `update-notifier` even after trying to bind it and change node versions. As I understood it there are some problems with this module currently?

If you have any tips for how to resolve this problem I can test it again 😄 

<img width="725" alt="image" src="https://user-images.githubusercontent.com/26817802/205862820-fdfa1c3d-7c09-439e-bf00-f51309dd7b62.png">

