### PR TITLE
Change theme default value as to meet WCAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ You can use all of the following options with the standalone version of the <red
     * `color`: # COMPUTED: colors.primary.main
     * `visited`: # COMPUTED: typography.links.color
     * `hover`: # COMPUTED: lighten(0.2 typography.links.color)
-    * `textDecoration`: 'auto'
-    * `hoverTextDecoration`: 'auto'
+    * `textDecoration`: 'underline'
+    * `hoverTextDecoration`: 'underline'
 * `sidebar`
   * `width`: '260px'
   * `backgroundColor`: '#fafafa'

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -128,8 +128,8 @@ const defaultTheme: ThemeInterface = {
       color: ({ colors }) => colors.primary.main,
       visited: ({ typography }) => typography.links.color,
       hover: ({ typography }) => lighten(0.2, typography.links.color),
-      textDecoration: 'auto',
-      hoverTextDecoration: 'auto',
+      textDecoration: 'underline',
+      hoverTextDecoration: 'underline',
     },
   },
   sidebar: {


### PR DESCRIPTION
## What/Why/How?

This solves: https://github.com/Redocly/redoc/issues/2225

In summary: The current default value for text decoration for links breaks WCAG 1.4.1, a level A fault. WCAG 1.4.1 says function should not be communicated by color alone. 

## Reference

## Testing

As per the problems mentioned in #2225 I have not been able to run the test properly. The changes are minimal and mainly visual.

## Screenshots (optional)
Before
<img width="984" alt="image" src="https://user-images.githubusercontent.com/26817802/205938619-7e4c04d5-b15d-4390-80ef-7d6a01e4ef43.png">

After
<img width="832" alt="image" src="https://user-images.githubusercontent.com/26817802/205938846-b85f1adc-d79c-4e07-a9f0-2e222bd82488.png">


## Check yourself

- [x] Code is linted
- [ ] Tested
- [x] All new/updated code is covered with tests
