### PR TITLE
Update developer setup with new dependency

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,6 +30,13 @@ After cloning the repo, run:
 $ npm install # or npm
 ```
 
+To run the dev server, you will also need to install the cli's dependencies:
+
+```bash
+$ cd cli
+$ npm install # or npm
+```
+
 ### Commonly used NPM scripts
 
 ``` bash


### PR DESCRIPTION
## What/Why/How?

While preparing to look into a bug in the redoc UI, I followed the setup instructions in `CONTRIBUTING.md` and found that `npm start` will not function unless I install the dependencies of the `cli` package.

## Reference


It seems like the UI is directly importing code from the CLI without reyling on the CLI as a dependency, so CLI's dependency on `update-notifier` is not tracked and the dev server can't transpile the UI because the import is not resolved, unless I first install the dependencies of the CLI.

Since I know nothing about this repo yet, I chose to update the developer setup instructions rather than try to understand the dependency issue more deeply.

## Testing

To repro the issue, just follow the setup instructions in `CONTRIBUTING.md` after a fresh clone. Note that the UI crashes. Then perform the additional step I mention in this PR. The UI stops crashing.

## Check yourself

- [X] Code is linted
- [X] Tested
