### PR TITLE
add some success response codes to openapi-3-1.yaml

### DIFF
--- a/demo/openapi-3-1.yaml
+++ b/demo/openapi-3-1.yaml
@@ -805,11 +805,17 @@ paths:
       parameters:
         - name: username
           in: path
-          description: name that need to be deleted
+          description: name that need to be updated
           required: true
           schema:
             type: string
       responses:
+        '200':
+          description: User is updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
         '400':
           description: Invalid user supplied
         '404':
@@ -835,6 +841,8 @@ paths:
           schema:
             type: string
       responses:
+        '204':
+          description: User is deleted
         '400':
           description: Invalid username supplied
         '404':


### PR DESCRIPTION
## What/Why/How?
In the demo schema `openapi-3-1.yaml` operations updateUser and deleteUser lack successful response descriptions.  
This PR adds 200 and 204 codes for them.