### PR TITLE
chore(deps): bump redoc from 2.0.0-rc.77 to 2.0.0

### DIFF
--- a/cli/npm-shrinkwrap.json
+++ b/cli/npm-shrinkwrap.json
@@ -16,7 +16,7 @@
         "node-libs-browser": "^2.2.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "redoc": "2.0.0-rc.77",
+        "redoc": "2.0.0",
         "styled-components": "^5.3.0",
         "update-notifier": "^5.0.1",
         "yargs": "^17.3.1"
@@ -2812,9 +2812,9 @@
       }
     },
     "node_modules/redoc": {
-      "version": "2.0.0-rc.77",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.77.tgz",
-      "integrity": "sha512-hiCMNSEl6R9vDkiVBMJSKxyT+wLY0qZdw+UZuOHWDCFm3uV0SELwTUU+spVBFCdzM4fdxjCnvsY2vX6cjcJNNg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0.tgz",
+      "integrity": "sha512-rU8iLdAkT89ywOkYk66Mr+IofqaMASlRvTew0dJvopCORMIPUcPMxjlJbJNC6wsn2vvMnpUFLQ/0ISDWn9BWag==",
       "dependencies": {
         "@redocly/openapi-core": "^1.0.0-beta.104",
         "classnames": "^2.3.1",
@@ -6107,9 +6107,9 @@
       }
     },
     "redoc": {
-      "version": "2.0.0-rc.77",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.77.tgz",
-      "integrity": "sha512-hiCMNSEl6R9vDkiVBMJSKxyT+wLY0qZdw+UZuOHWDCFm3uV0SELwTUU+spVBFCdzM4fdxjCnvsY2vX6cjcJNNg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0.tgz",
+      "integrity": "sha512-rU8iLdAkT89ywOkYk66Mr+IofqaMASlRvTew0dJvopCORMIPUcPMxjlJbJNC6wsn2vvMnpUFLQ/0ISDWn9BWag==",
       "requires": {
         "@redocly/openapi-core": "^1.0.0-beta.104",
         "classnames": "^2.3.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -18,7 +18,7 @@
     "node-libs-browser": "^2.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "redoc": "2.0.0-rc.77",
+    "redoc": "2.0.0",
     "styled-components": "^5.3.0",
     "update-notifier": "^5.0.1",
     "yargs": "^17.3.1"


### PR DESCRIPTION
## What/Why/How?

In cli, bump redoc version from 2.0.0-rc.77 (**RC**) to 2.0.0 (**STABLE**)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
