### PR TITLE
adds ability to override default font family

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -30,6 +30,7 @@ ENV BASE_PATH=
 ENV SPEC_URL="http://petstore.swagger.io/v2/swagger.json"
 ENV PORT=80
 ENV REDOC_OPTIONS=
+ENV FONT_FAMILY_URL="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
 
 # copy files to the nginx folder
 COPY --from=0 build/bundles /usr/share/nginx/html

--- a/config/docker/README.md
+++ b/config/docker/README.md
@@ -49,6 +49,7 @@ Another issue with OpenShift is that the default exposed port `80` cannot be use
 - `SPEC_URL` (default `"http://petstore.swagger.io/v2/swagger.json"`) - URL to spec
 - `PORT` (default `80`) - nginx port
 - `REDOC_OPTIONS` (optional) - [`<redoc>` tag attributes](https://github.com/Redocly/redoc#redoc-tag-attributes)
+- `FONT_FAMILY_URL` (default `"https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"`) - URL to font family
 
 ## Build
 

--- a/config/docker/docker-run.sh
+++ b/config/docker/docker-run.sh
@@ -7,6 +7,7 @@ sed -i -e "s|%PAGE_FAVICON%|$PAGE_FAVICON|g" /usr/share/nginx/html/index.html
 sed -i -e "s|%BASE_PATH%|$BASE_PATH|g" /usr/share/nginx/html/index.html
 sed -i -e "s|%SPEC_URL%|$SPEC_URL|g" /usr/share/nginx/html/index.html
 sed -i -e "s|%REDOC_OPTIONS%|${REDOC_OPTIONS}|g" /usr/share/nginx/html/index.html
+sed -i -e "s|%FONT_FAMILY_URL%|${FONT_FAMILY_URL}|g" /usr/share/nginx/html/index.html
 sed -i -e "s|\(listen\s*\) [0-9]*|\1 ${PORT}|g" /etc/nginx/nginx.conf
 
 exec nginx -g 'daemon off;'

--- a/config/docker/index.tpl.html
+++ b/config/docker/index.tpl.html
@@ -16,7 +16,7 @@
       }
     </style>
     <link
-      href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
+      href="%FONT_FAMILY_URL%"
       rel="stylesheet"
     />
   </head>


### PR DESCRIPTION
## What/Why/How?
- Adds ability to configure font family
- Ability to match look and feel of existing websites
- Move original `href` value to ENV var as default, `sed` to replace %FONT_FAMILY_URL%

## Reference
- Duplicates process from this PR

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
