### PR TITLE
docs: updates the redocly cli command prefix from openapi to redocly

### DIFF
--- a/docs/deployment/intro.md
+++ b/docs/deployment/intro.md
@@ -55,7 +55,7 @@ If you have [Redocly CLI](https://redocly.com/docs/cli/#installation-and-usage) 
 project directory and run the following command:
 
 ```bash
-openapi preview-docs openapi.yaml
+redocly preview-docs openapi.yaml
 ```
 
 Replace `openapi.yaml` in the example command with the file path to your OpenAPI definition.
@@ -66,7 +66,7 @@ To exit the preview, use `control+C`.
 You can alter the port if you are using 8080 already, for example:
 
 ```bash
-openapi preview-docs -p 8888 openapi.yaml
+redocly preview-docs -p 8888 openapi.yaml
 ```
 
 Replace `openapi.yaml` in the example command with the file path to your OpenAPI definition.


### PR DESCRIPTION
## What/Why/How?

The redocly CLI command prefix has been updated from openapi to redocly so this documentation needs to be updated to reflect that update.

## Check yourself

- [x] Code is linted
