### PR TITLE
feat：Chinese search is supported

### DIFF
--- a/demo/openapi.yaml
+++ b/demo/openapi.yaml
@@ -1216,7 +1216,7 @@ components:
 x-webhooks:
   newPet:
     post:
-      summary: New pet
+      summary: New pet 中文测试
       description: Information about a new pet in the systems
       operationId: newPet
       tags:

--- a/src/services/SearchWorker.worker.ts
+++ b/src/services/SearchWorker.worker.ts
@@ -28,8 +28,6 @@ function initEmpty() {
   builder.field('description');
   builder.ref('ref');
 
-  builder.pipeline.add(lunr.trimmer, lunr.stopWordFilter, lunr.stemmer);
-
   index = new Promise(resolve => {
     resolveIndex = resolve;
   });
@@ -38,8 +36,7 @@ function initEmpty() {
 initEmpty();
 
 const expandTerm = term => {
-  const token = lunr.trimmer(new lunr.Token(term, {}));
-  return '*' + lunr.stemmer(token) + '*';
+  return `*${term}*`;
 };
 
 export function add<T>(title: string, description: string, meta?: T) {


### PR DESCRIPTION
What:
This PR aims to add support for Chinese search functionality in ReDoc. Currently, ReDoc supports searching API documentation using English keywords, but this feature request proposes extending the search capability to include Chinese language support. With this enhancement, users will be able to search for API endpoints, methods, and descriptions using both English and Chinese keywords.

Why:
Adding Chinese search support is important to cater to a wider user base, especially in regions where Chinese is the primary language. By enabling users to search for API documentation using Chinese keywords, ReDoc becomes more accessible and user-friendly for Chinese-speaking developers. This enhancement aligns with the goal of making ReDoc a versatile and inclusive tool for API documentation.

How:
Currently, there are only Node.js and WebAssembly-based Chinese word segmentation libraries available on npm.
In order to support Chinese search. So you hid the English word segmentation functionality

## Tests

## Screenshots (optional)

issue：https://github.com/Redocly/redoc/issues/2373#issuecomment-1670749332

## Check yourself

- [ yes ] Code is linted
- [ yes ] Tested
- [ yes ] All new/updated code is covered with tests
