### PR TITLE
hotfix: fix crash after 2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.1.1](https://github.com/Redocly/redoc/compare/v2.1.0...v2.1.1) (2023-08-17)
+
+
+### Bug Fixes
+
+* hotfix, crash after 2.1 release ([0ab3428](https://github.com/Redocly/redoc/commit/0ab3428664f857ea07381686a2b4beb4c22b17c3))
+
+
+
 # [2.1.0](https://github.com/Redocly/redoc/compare/v2.0.0...v2.1.0) (2023-08-10)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "redoc",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redoc",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^1.0.0-rc.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redoc",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "ReDoc",
   "repository": {
     "type": "git",

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -393,7 +393,7 @@ export function getSerializedValue(field: FieldModel, example: any) {
     // decode for better readability in examples: see https://github.com/Redocly/redoc/issues/1138
     return decodeURIComponent(serializeParameterValue(field, example));
   } else {
-    return example;
+    return String(example);
   }
 }
 


### PR DESCRIPTION
## What/Why/How?

Crash after 2.1 release due to wrong conversion to string.

## Reference

Resolves https://github.com/Redocly/redoc/issues/2385

## Tests

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
