### PR TITLE
Style RefreshToken URL as <code> in the OAuthFlow

### DIFF
--- a/src/components/SecurityRequirement/OAuthFlow.tsx
+++ b/src/components/SecurityRequirement/OAuthFlow.tsx
@@ -39,7 +39,7 @@ export function OAuthFlowComponent(props: OAuthFlowProps) {
       {flow!.refreshUrl && (
         <SecurityRow>
           <strong> Refresh URL: </strong>
-          {flow!.refreshUrl}
+          <code>{flow!.refreshUrl}</code>
         </SecurityRow>
       )}
       {!!scopesNames.length && (


### PR DESCRIPTION
Represent refreshToken URL in a similar fashion like Token URL is styled, for consistency in rendering.

## What/Why/How?
When an OAuth security scheme definition is rendered the refreshToken URL is presented as plain text, but it should be a (non-clickable) URL, rendered via `<code>` tag, as the tokenURL is rendered.
One line of template is changed

## Reference

## Tests

## Screenshots (optional)
the wrong rendering:
![image](https://github.com/Redocly/redoc/assets/14344182/ce7d7b78-e035-46b9-9a02-97f73c5bd6d7)

better rendering:
![image](https://github.com/Redocly/redoc/assets/14344182/df1d78af-7df9-4c79-b6dd-de9eea72d93a)



## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
