### PR TITLE
fix: default value as object in request body

### DIFF
--- a/src/components/Fields/FieldDetails.tsx
+++ b/src/components/Fields/FieldDetails.tsx
@@ -51,10 +51,10 @@ export const FieldDetailsComponent = observer((props: FieldProps) => {
 
     return null;
   }, [field, showExamples]);
-
-  const defaultValue = isObject(schema.default)
-    ? getSerializedValue(field, schema.default).replace(`${field.name}=`, '')
-    : schema.default;
+  const defaultValue =
+    isObject(schema.default) && field.in
+      ? getSerializedValue(field, schema.default).replace(`${field.name}=`, '')
+      : schema.default;
 
   return (
     <div>

--- a/src/components/__tests__/FieldDetails.test.tsx
+++ b/src/components/__tests__/FieldDetails.test.tsx
@@ -44,4 +44,36 @@ describe('FieldDetailsComponent', () => {
 
     expect(wrapper.render()).toMatchSnapshot();
   });
+
+  it('renders correctly when default value is object in request body', () => {
+    const mockFieldProps = {
+      showExamples: true,
+      field: {
+        schema: {
+          type: 'object',
+          default: { properties: {} },
+          displayType: 'object',
+          title: 'test title',
+          externalDocs: undefined,
+          constraints: [''],
+        } as SchemaModel,
+        example: 'example',
+        name: 'name',
+        expanded: false,
+        required: false,
+        kind: '',
+        deprecated: false,
+        collapse: jest.fn(),
+        toggle: jest.fn(),
+        explode: false,
+        expand: jest.fn(),
+        description: 'test description',
+        in: undefined,
+      },
+      renderDiscriminatorSwitch: jest.fn(),
+    };
+    const wrapper = shallow(withTheme(<FieldDetails {...mockFieldProps} />));
+
+    expect(wrapper.render()).toMatchSnapshot();
+  });
 });

--- a/src/components/__tests__/__snapshots__/FieldDetails.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FieldDetails.test.tsx.snap
@@ -37,7 +37,73 @@ exports[`FieldDetailsComponent renders correctly 1`] = `
     <span
       class="sc-kpDqfm sc-eldPxv cGRfjn ehWiAn"
     >
-      ""
+      []
+    </span>
+  </div>
+   
+  <div>
+    <span
+      class="sc-kpDqfm cGRfjn"
+    >
+       Example: 
+    </span>
+     
+    <span
+      class="sc-kpDqfm sc-eldPxv cGRfjn ehWiAn"
+    >
+      "example"
+    </span>
+  </div>
+  <div>
+    <div
+      class="sc-lcIPJg sc-hknOHE gBHqkN jFBMaE"
+    >
+      <p>
+        test description
+      </p>
+      
+
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FieldDetailsComponent renders correctly when default value is object in request body 1`] = `
+<div>
+  <div>
+    <span
+      class="sc-kpDqfm sc-dAlyuH cGRfjn gHomYR"
+    />
+    <span
+      class="sc-kpDqfm sc-jlZhew cGRfjn dYtiIA"
+    >
+      object
+    </span>
+    <span
+      class="sc-kpDqfm sc-cwHptR cGRfjn gyVIPr"
+    >
+       (test title) 
+    </span>
+    <span>
+       
+      <span
+        class="sc-kpDqfm sc-gFqAkR cGRfjn fYEICH"
+      >
+          
+      </span>
+    </span>
+  </div>
+  <div>
+    <span
+      class="sc-kpDqfm cGRfjn"
+    >
+       Default: 
+    </span>
+     
+    <span
+      class="sc-kpDqfm sc-eldPxv cGRfjn ehWiAn"
+    >
+      {"properties":{}}
     </span>
   </div>
    


### PR DESCRIPTION
## What/Why/How?
When request body has default value as object we display `[object Object]`. 
fixes: https://github.com/Redocly/redoc/issues/2423
## Reference

## Tests

## Screenshots (optional)
_Before_
![271993133-655283d6-75bb-4401-ae35-fcc0dd405482](https://github.com/Redocly/redoc/assets/14113673/2b3f3635-b1a8-4a2e-b296-b46551683a69)

_After_
<img width="953" alt="Screenshot 2023-10-22 at 12 55 14" src="https://github.com/Redocly/redoc/assets/14113673/9e2eee1d-a092-4851-b33e-db211cbf526c">

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
