### PR TITLE
docs: Remove references to interactive docs in the open source project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img alt="Redoc logo" src="https://raw.githubusercontent.com/Redocly/redoc/main//docs/images/redoc.png" width="400px" />
 
-  # Generate beautiful API documentation from OpenAPI definitions
+  # Generate beautiful API documentation from OpenAPI
 
   [![npm](http://img.shields.io/npm/v/redoc.svg)](https://www.npmjs.com/package/redoc) [![License](https://img.shields.io/npm/l/redoc.svg)](https://github.com/Redocly/redoc/blob/main/LICENSE)
 


### PR DESCRIPTION
## What/Why/How?

Fixes #2377 - since we still describe the API documentation as interactive although Try It is not included in the open source version. This pull request updates some language to clarify the status in the readme.

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
