### PR TITLE
docs: Remove outdated sync job for docs folder

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,6 +1,0 @@
-group:
-  - files:
-      - source: docs/
-        dest: docs/redoc
-    repos: |
-      Redocly/docs


### PR DESCRIPTION
## What/Why/How?

We don't need to sync any more, since switching to fetching these docs with the remote content feature.

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
