### PR TITLE
docs: Fix a link that couldn't be checked as it reaches outside the Redoc project

### DIFF
--- a/docs/deployment/cli.md
+++ b/docs/deployment/cli.md
@@ -14,7 +14,7 @@ First, you need to install the `@redocly/cli` package.
 
 You can install it [globally](../../cli/installation.md#install-globally) using npm or Yarn.
 
-Or you can install it during [runtime](../../installation.md#use-npx-at-runtime) using npx or Docker.
+Or you can install it during [runtime](../../cli/installation.md#use-npx-at-runtime) using npx or Docker.
 
 ## Step 2 - Build the HTML file
 


### PR DESCRIPTION
## What/Why/How?

Tiny link fix! In the context of the Redoc docs, the link checker can't check links that point to the locations in the wider marketing site. The link checker in that project caught the error, but it must be fixed here.

## Reference

broken build (Redocly users only) https://github.com/Redocly/marketing-site-portal/actions/runs/7712790410/job/21021123579?pr=1190

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
