### PR TITLE
Add deprecated css to clickable property name

### DIFF
--- a/src/common-elements/fields.ts
+++ b/src/common-elements/fields.ts
@@ -1,10 +1,17 @@
 import { transparentize } from 'polished';
 
-import styled, { extensionsHook, css } from '../styled-components';
+import styled, { css, extensionsHook } from '../styled-components';
 import { PropertyNameCell } from './fields-layout';
+import { deprecatedCss } from './mixins';
 import { ShelfIcon } from './shelfs';
 
 export const ClickablePropertyNameCell = styled(PropertyNameCell)`
+  &.deprecated {
+    span.property-name {
+      ${deprecatedCss}
+    }
+  }
+
   button {
     background-color: transparent;
     border: 0;


### PR DESCRIPTION
## What/Why/How?
What: ClickablePropertyName styled component doesn't pass the deprecated css to its child `<span class='property-name'>` and because of that property name doesn't get line-through style.

Solved it by adding the missing css code.

## Reference
-
## Tests
No tests needed
## Screenshots (optional)
Before:
<img width="468" alt="image" src="https://github.com/Redocly/redoc/assets/43813768/25a88c0f-d64f-4066-a40e-0abb3aea427a">
After:
<img width="468" alt="image" src="https://github.com/Redocly/redoc/assets/43813768/60856455-b4a9-4754-bd45-7db622a6ed76">


## Check yourself

- [x] Code is linted
- [X] Tested
- [X] All new/updated code is covered with tests
