### PR TITLE
Allow showing SchemaDefinition as child

### DIFF
--- a/src/components/SchemaDefinition/SchemaDefinition.tsx
+++ b/src/components/SchemaDefinition/SchemaDefinition.tsx
@@ -15,6 +15,7 @@ export interface ObjectDescriptionProps {
   showReadOnly?: boolean;
   showWriteOnly?: boolean;
   showExample?: boolean;
+  showAsChild?: boolean;
   parser: OpenAPIParser;
   options: RedocNormalizedOptions;
 }
@@ -39,15 +40,10 @@ export class SchemaDefinition extends React.PureComponent<ObjectDescriptionProps
   private _mediaModel: MediaTypeModel;
 
   private get mediaModel() {
-    const { parser, schemaRef, exampleRef, options } = this.props;
+    const { parser, schemaRef, exampleRef, options, showAsChild } = this.props;
     if (!this._mediaModel) {
-      this._mediaModel = new MediaTypeModel(
-        parser,
-        'json',
-        false,
-        SchemaDefinition.getMediaType(schemaRef, exampleRef),
-        options,
-      );
+      const info = SchemaDefinition.getMediaType(schemaRef, exampleRef);
+      this._mediaModel = new MediaTypeModel(parser, 'json', false, info, options, showAsChild);
     }
 
     return this._mediaModel;

--- a/src/services/models/MediaType.ts
+++ b/src/services/models/MediaType.ts
@@ -25,10 +25,11 @@ export class MediaTypeModel {
     isRequestType: boolean,
     info: OpenAPIMediaType,
     options: RedocNormalizedOptions,
+    showAsChild?: boolean,
   ) {
     this.name = name;
     this.isRequestType = isRequestType;
-    this.schema = info.schema && new SchemaModel(parser, info.schema, '', options);
+    this.schema = info.schema && new SchemaModel(parser, info.schema, '', options, showAsChild);
     this.onlyRequiredInSamples = options.onlyRequiredInSamples;
     this.generatedPayloadSamplesMaxDepth = options.generatedPayloadSamplesMaxDepth;
     if (info.examples !== undefined) {


### PR DESCRIPTION
## What/Why/How?

When using SchemaDefinition to show a ref that is a child of an object with discriminator, sometimes you want to show that exact child, and not the parent. 

## Reference

## Tests

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
