### PR TITLE
fix: show siblings schema with oneOf

### DIFF
--- a/src/services/OpenAPIParser.ts
+++ b/src/services/OpenAPIParser.ts
@@ -364,14 +364,18 @@ export class OpenAPIParser {
 
     const allOf = schema.allOf;
     for (let i = 0; i < allOf.length; i++) {
-      const sub = allOf[i];
-      if (Array.isArray(sub.oneOf)) {
+      const { oneOf, ...sub } = allOf[i];
+      if (!oneOf) {
+        continue;
+      }
+      if (Array.isArray(oneOf)) {
         const beforeAllOf = allOf.slice(0, i);
         const afterAllOf = allOf.slice(i + 1);
+        const siblingValues = Object.keys(sub).length > 0 ? [sub] : [];
         return {
-          oneOf: sub.oneOf.map((part: OpenAPISchema) => {
+          oneOf: oneOf.map((part: OpenAPISchema) => {
             return {
-              allOf: [...beforeAllOf, part, ...afterAllOf],
+              allOf: [...beforeAllOf, ...siblingValues, part, ...afterAllOf],
               'x-refsStack': refsStack,
             };
           }),

--- a/src/services/__tests__/__snapshots__/OpenAPIParser.test.ts.snap
+++ b/src/services/__tests__/__snapshots__/OpenAPIParser.test.ts.snap
@@ -23,6 +23,14 @@ exports[`Models Schema should hoist oneOfs when mergin allOf 1`] = `
       "allOf": [
         {
           "properties": {
+            "id": {
+              "description": "The user's ID",
+              "type": "integer",
+            },
+          },
+        },
+        {
+          "properties": {
             "username": {
               "description": "The user's name",
               "type": "string",
@@ -63,8 +71,65 @@ exports[`Models Schema should hoist oneOfs when mergin allOf 1`] = `
       "allOf": [
         {
           "properties": {
+            "id": {
+              "description": "The user's ID",
+              "type": "integer",
+            },
+          },
+        },
+        {
+          "properties": {
             "email": {
               "description": "The user's email",
+              "type": "string",
+            },
+          },
+        },
+        {
+          "properties": {
+            "extra": {
+              "type": "string",
+            },
+          },
+        },
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "password": {
+                  "description": "The user's password",
+                  "type": "string",
+                },
+              },
+            },
+            {
+              "properties": {
+                "mobile": {
+                  "description": "The user's mobile",
+                  "type": "string",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "x-refsStack": undefined,
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "id": {
+              "description": "The user's ID",
+              "type": "integer",
+            },
+          },
+        },
+        {
+          "properties": {
+            "id": {
+              "description": "The user's ID",
+              "format": "uuid",
               "type": "string",
             },
           },

--- a/src/services/__tests__/fixtures/oneOfHoist.json
+++ b/src/services/__tests__/fixtures/oneOfHoist.json
@@ -9,6 +9,12 @@
       "test": {
         "allOf": [
           {
+            "properties": {
+              "id": {
+                "description": "The user's ID",
+                "type": "integer"
+              }
+            },
             "oneOf": [
               {
                 "properties": {
@@ -23,6 +29,15 @@
                   "email": {
                     "description": "The user's email",
                     "type": "string"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "id": {
+                    "description": "The user's ID",
+                    "type": "string",
+                    "format": "uuid"
                   }
                 }
               }


### PR DESCRIPTION
## What/Why/How?
fix a bug when oneOf has siblings and it doesn't render correct
fixes https://github.com/Redocly/redoc/issues/641
fixes https://github.com/Redocly/redoc/issues/743
```yaml
   Main:
      title: Sale
      description: A request to authorize and capture funds.
      allOf:
        - $ref: '#/components/schemas/Anything1'
        - type: object
          properties:
            d:
              type: number
          oneOf:
            - $ref: '#/components/schemas/Anything2'
            - $ref: '#/components/schemas/Anything3'
    Anything1:
      type: object
      properties:
        a:
          type: string

    Anything2:
      type: object
      properties:
        b:
          type: string

    Anything3:
      type: object
      properties:
        c:
          type: string
```
```yaml
   foo:
      type: object
      properties:
        property1:
          type: string
        property2:
          type: string
        property3:
          type: string
        property4:
          type: string
        property5:
          type: string
        property6:
          type: string
      oneOf:
        - required:
          - property1
          - property2
          - property6
        - required:
          - property1
          - property5
```
## Reference

## Tests

## Screenshots (optional)
**Before**
<img width="709" alt="Screenshot 2024-08-29 at 17 29 00" src="https://github.com/user-attachments/assets/11706b61-2ad1-4409-a5a3-65560fa3ce30">
<img width="675" alt="Screenshot 2024-08-29 at 17 40 03" src="https://github.com/user-attachments/assets/f7e14038-14c7-45c6-9994-52b090eb2c43">

**After**
<img width="687" alt="Screenshot 2024-08-29 at 17 28 31" src="https://github.com/user-attachments/assets/37d510cf-216f-4427-8814-306ea7648b95">
 
<img width="686" alt="Screenshot 2024-08-29 at 17 39 28" src="https://github.com/user-attachments/assets/604b6a8b-9c4a-4323-aa1c-938f8ac483d1">
<img width="683" alt="Screenshot 2024-08-29 at 17 39 34" src="https://github.com/user-attachments/assets/11ff8206-7bd1-49f1-9282-f9e4ba892dd6">


## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
