### PR TITLE
docs: update broken link of Openapi Object

### DIFF
--- a/docs/redoc-vendor-extensions.md
+++ b/docs/redoc-vendor-extensions.md
@@ -50,7 +50,7 @@ You can use the following [vendor extensions](https://redocly.com/docs/openapi-v
       - [x-explicitMappingOnly example](#x-explicitmappingonly-example)
 
 ## Swagger Object
-Extends the OpenAPI root [OpenAPI Object](https://redocly.com/docs/openapi-visual-reference/openapi-1/)
+Extends the OpenAPI root [OpenAPI Object](https://redocly.com/docs/openapi-visual-reference/openapi)
 
 ### x-servers
 Backported from OpenAPI 3.0 [`servers`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#serverObject). Currently doesn't support templates.


### PR DESCRIPTION
## What/Why/How?
update broken link in OSS Redoc docs
## Reference

https://github.com/Redocly/redoc/actions/runs/10618307816/job/29433195630?pr=2576
## Tests

## Screenshots (optional)
<img width="943" alt="Screenshot 2024-08-29 at 17 57 05" src="https://github.com/user-attachments/assets/f5c912b8-5de7-4e80-8789-cb40f4fe6731">

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
