### PR TITLE
docs: Remove the old zero-dependency claim for Redoc docs

### DIFF
--- a/docs/deployment/cli.md
+++ b/docs/deployment/cli.md
@@ -6,7 +6,7 @@ seo:
 # How to use the Redocly CLI
 
 With Redocly CLI, you can bundle your OpenAPI definition and API documentation
-(made with Redoc) into a zero-dependency HTML file and render it locally.
+(made with Redoc) into an HTML file and render it locally.
 
 ## Step 1 - Install Redocly CLI
 
@@ -18,9 +18,9 @@ Or you can install it during [runtime](../../cli/installation.md#use-npx-at-runt
 
 ## Step 2 - Build the HTML file
 
-The Redocly CLI `build-docs` command builds Redoc into a zero-dependency HTML file.
+The Redocly CLI `build-docs` command builds Redoc into an HTML file.
 
-To build a zero-dependency HTML file using Redocly CLI, enter the following command,
+To build an HTML file using Redocly CLI, enter the following command,
 replacing `apis/openapi.yaml` with your API definition file's name and path:
 
 ```bash


### PR DESCRIPTION
## What/Why/How?

Older versions of Redoc claimed to be "zero-dependency" but that's not correct for the current version. It was still mentioned in the CLI guide, so this pull request updates those references.

Fixes https://github.com/Redocly/redocly-cli/issues/1731

## Reference

https://redocly.com/docs/redoc/deployment/cli

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
