### PR TITLE
feat: update pattern styling (#2196)

### DIFF
--- a/src/common-elements/fields.ts
+++ b/src/common-elements/fields.ts
@@ -97,9 +97,11 @@ export const RecursiveLabel = styled(FieldLabel)`
 
 export const PatternLabel = styled(FieldLabel)`
   color: #0e7c86;
+  font-family: ${props => props.theme.typography.code.fontFamily};
+  font-size: 12px;
   &::before,
   &::after {
-    font-weight: bold;
+    content: ' ';
   }
 `;
 

--- a/src/components/__tests__/__snapshots__/FieldDetails.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FieldDetails.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`FieldDetailsComponent renders correctly when field items have string ty
     >
       [
       <span
-        class="sc-kpDqfm sc-eDPEul cGRfjn erJHow"
+        class="sc-kpDqfm sc-eDPEul cGRfjn cCKYVD"
       >
         ^see regex[0-9]$
       </span>


### PR DESCRIPTION
Hello,

This is a small change that adjusts the styling for patterns being displayed inline for a field.

I've included before and after screenshots using a part of the pet store example.

![image](https://github.com/user-attachments/assets/7854c5fa-8c7e-44cd-961e-74c363aff41e)

![image](https://github.com/user-attachments/assets/d4c5a494-5b62-4598-bad0-63c9a2560e50)

---

Closes #2196 
