### PR TITLE
feat: add option to show the description when using the `SchemaDefininition` component

### DIFF
--- a/src/components/SchemaDefinition/SchemaDefinition.tsx
+++ b/src/components/SchemaDefinition/SchemaDefinition.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Markdown } from '../Markdown/Markdown';
 import { DarkRightPanel, MiddlePanel, MimeLabel, Row, Section } from '../../common-elements';
 import { MediaTypeModel, OpenAPIParser, RedocNormalizedOptions } from '../../services';
 import styled from '../../styled-components';
@@ -15,6 +16,7 @@ export interface ObjectDescriptionProps {
   showReadOnly?: boolean;
   showWriteOnly?: boolean;
   showExample?: boolean;
+  showDescription?: boolean;
   parser: OpenAPIParser;
   options: RedocNormalizedOptions;
 }
@@ -54,11 +56,19 @@ export class SchemaDefinition extends React.PureComponent<ObjectDescriptionProps
   }
 
   render() {
-    const { showReadOnly = true, showWriteOnly = false, showExample = true } = this.props;
+    const {
+      showReadOnly = true,
+      showWriteOnly = false,
+      showExample = true,
+      showDescription = false,
+    } = this.props;
     return (
       <Section>
         <Row>
           <MiddlePanel>
+            {showDescription && this.mediaModel.schema?.description && (
+              <Markdown source={this.mediaModel.schema.description} />
+            )}
             <Schema
               skipWriteOnly={!showWriteOnly}
               skipReadOnly={!showReadOnly}

--- a/src/components/__tests__/SchemaDefinition.test.tsx
+++ b/src/components/__tests__/SchemaDefinition.test.tsx
@@ -22,6 +22,15 @@ describe('Components', () => {
         components: {
           schemas: {
             test: {
+              description: 'schema_description',
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'string',
+                },
+              },
+            },
+            test_no_description: {
               type: 'object',
               properties: {
                 id: {
@@ -76,6 +85,69 @@ describe('Components', () => {
           ),
         );
         expect(component.html().includes('<code>')).toBe(false);
+      });
+    });
+
+    describe('Show description constraints', () => {
+      it('should hide the description as default', () => {
+        const component = shallow(
+          withTheme(
+            <SchemaDefinition
+              schemaRef="#/components/schemas/test"
+              parser={parser}
+              options={options}
+              showExample={false}
+            />,
+          ),
+        );
+        expect(component.html().includes('schema_description')).toBe(false);
+      });
+
+      it('should hide the description if `showDescription` is `false`', () => {
+        const component = shallow(
+          withTheme(
+            <SchemaDefinition
+              schemaRef="#/components/schemas/test"
+              parser={parser}
+              options={options}
+              showExample={false}
+              showDescription={false}
+            />,
+          ),
+        );
+        expect(component.html().includes('schema_description')).toBe(false);
+      });
+
+      it('should show the description if `showDescription` is `true`', () => {
+        const component = shallow(
+          withTheme(
+            <SchemaDefinition
+              schemaRef="#/components/schemas/test"
+              parser={parser}
+              options={options}
+              showExample={false}
+              showDescription={true}
+            />,
+          ),
+        );
+        expect(component.html().includes('schema_description')).toBe(true);
+      });
+
+      it('not to thrown error if `showDescription` is `true` and without description', () => {
+        const component = shallow(
+          withTheme(
+            <SchemaDefinition
+              schemaRef="#/components/schemas/test_no_description"
+              parser={parser}
+              options={options}
+              showExample={false}
+              showDescription={true}
+            />,
+          ),
+        );
+        expect(() => {
+          component.html();
+        }).not.toThrow();
       });
     });
   });


### PR DESCRIPTION
## What/Why/How?

This change allows show the description of schema definition..
I choose default value of showDescription is false, because it keep current behavior for existing using of the component.

The PR solves https://github.com/Redocly/redoc/issues/1840.

If set `showDescription={true}` in following code, schema description is shown in tag related schema.
The PR doesn't include the change in following code.
However I expect that schema description is rendered when `x-tags` is specified.

https://github.com/Redocly/redoc/blob/11912f5d9160aa21a5230ae48b9f6872cc01fe35/src/services/MenuBuilder.ts#L278 


## Reference

- https://github.com/Redocly/redoc/issues/1840

## Tests

Add some tests for SchemaDefinition.

## Screenshots (optional)

![image](https://github.com/user-attachments/assets/ccdcdaf0-3d5b-41ce-8720-adb4cfe0755d)

<details>
<summary>OpenAPI spec for above screenshot</summary>

```yaml
openapi: 3.1.0
info:
  title: SchemaDefinition showDescription demo.

tags:
  - name: Test1
    x-displayName: The Schema with description(showDescription=false)
    description: |
      <SchemaDefinition schemaRef="#/components/schemas/SchemaWithDescription" showExample={true} showDescription={false}/>
  - name: Test2
    x-displayName: The Schema with description(showDescription=true)
    description: |
      <SchemaDefinition schemaRef="#/components/schemas/SchemaWithDescription" showExample={false} showDescription={true}/>
  - name: Test3
    x-displayName: The Schema without description(showDescription=true)
    description: |
      <SchemaDefinition schemaRef="#/components/schemas/SchemaWithoutDescription" showExample={true} showDescription={true}/>

components:
  schemas:
    SchemaWithDescription:
      title: Schema with Description
      description: |
        ### Schema description

        ```js
        let pet = {id: "cat"}
        ```
      type: object
      properties:
        id:
          type: string

    SchemaWithoutDescription:
      title: Schema without description
      type: object
      properties:
        id:
          type: string
```
</details>

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
