### PR TITLE
fix: displaying nested items with type string

### DIFF
--- a/src/components/Fields/ArrayItemDetails.tsx
+++ b/src/components/Fields/ArrayItemDetails.tsx
@@ -18,14 +18,6 @@ export function ArrayItemDetails({ schema }: { schema: SchemaModel }) {
     return null;
   }
 
-  if (schema.type === 'string' && schema.pattern) {
-    return (
-      <Wrapper>
-        [<Pattern schema={schema} />]
-      </Wrapper>
-    );
-  }
-
   return (
     <Wrapper>
       [ items

--- a/src/components/Fields/FieldDetails.tsx
+++ b/src/components/Fields/FieldDetails.tsx
@@ -8,7 +8,7 @@ import {
   TypePrefix,
   TypeTitle,
 } from '../../common-elements/fields';
-import { getSerializedValue, isObject } from '../../utils';
+import { getSerializedValue, isArray, isObject } from '../../utils';
 import { ExternalDocumentation } from '../ExternalDocumentation/ExternalDocumentation';
 import { Markdown } from '../Markdown/Markdown';
 import { EnumValues } from './EnumValues';
@@ -30,7 +30,8 @@ export const FieldDetailsComponent = observer((props: FieldProps) => {
 
   const { showExamples, field, renderDiscriminatorSwitch } = props;
   const { schema, description, deprecated, extensions, in: _in, const: _const } = field;
-  const isArrayType = schema.type === 'array';
+  const isArrayType =
+    schema.type === 'array' || (isArray(schema.type) && schema.type.includes('array'));
 
   const rawDefault = enumSkipQuotes || _in === 'header'; // having quotes around header field default values is confusing and inappropriate
 

--- a/src/components/__tests__/FieldDetails.test.tsx
+++ b/src/components/__tests__/FieldDetails.test.tsx
@@ -90,7 +90,7 @@ describe('FieldDetailsComponent', () => {
           items: {
             type: 'string',
             pattern: '^see regex[0-9]$',
-            constraints: [''],
+            constraints: ['<= 128 characters'],
             externalDocs: undefined,
           },
         } as any as SchemaModel,

--- a/src/components/__tests__/__snapshots__/FieldDetails.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FieldDetails.test.tsx.snap
@@ -161,13 +161,21 @@ exports[`FieldDetailsComponent renders correctly when field items have string ty
     <span
       class="sc-kpDqfm sc-dAlyuH sc-dxcDKg cGRfjn gHomYR gXntsr"
     >
-      [
+      [ items
+      <span>
+         
+        <span
+          class="sc-kpDqfm sc-gFqAkR cGRfjn fYEICH"
+        >
+           &lt;= 128 characters 
+        </span>
+      </span>
       <span
         class="sc-kpDqfm sc-eDPEul cGRfjn cCKYVD"
       >
         ^see regex[0-9]$
       </span>
-      ]
+       ]
     </span>
   </div>
    


### PR DESCRIPTION
## What/Why/How?
fix displaying nested items with type string.

## Reference
fixes: https://github.com/Redocly/redoc/issues/2516
fixes: https://github.com/Redocly/redoc/issues/2544
https://github.com/Redocly/redoc/issues/2358

## Tests
```yaml
EndpointIn:
      type: object
      properties:
        uid:
          description: Optional unique identifier for the endpoint
          type: string
          maxLength: 256
          minLength: 1
          pattern: ^[a-zA-Z0-9\-_.]+$
          example: unique-ep-identifier
          nullable: true
        plain_property:
          type: string
          pattern: '^[A-Z]+$'
          minLength: 1
          maxLength: 10
        array_items:
          type: array
          items:
            type: string
            pattern: '^[A-Z]+$'
            minLength: 1
            maxLength: 10
        macList:
          type: array
          description: MAC address list
          items:
            type: string
            pattern: ^([0-9a-f]{2}:){5}[0-9a-f]{2}$
        macList1:
          type: array
          description: MAC address list
          items:
            type: string
            pattern: ^([0-9a-f]{2}:){5}[0-9a-f]{2}$
            minLength: 17
            maxLength: 17
        channels:
          description: List of message channels this endpoint listens to (omit for all)
          type: array
          items:
            type: string
            maxLength: 128
            pattern: ^[a-zA-Z0-9\-_.]+$
            example: project_1337
          maxItems: 10
          minItems: 1
          uniqueItems: true
          nullable: true
          example:
            - project_123
            - group_2
        channels1:
          description: List of message channels this endpoint listens to (omit for all)
          type: array
          items:
            - type: string
              maxLength: 128
              pattern: ^[a-zA-Z0-9\-_.]+$
              example: project_1337
            - type: string
              maxLength: 128
              pattern: ^[a-zA-Z0-9\-_.]+$
              example: project_1337
          maxItems: 10
          minItems: 1
          uniqueItems: true
          nullable: true
          example:
            - project_123
            - group_2
```
## Screenshots (optional)
_BEFORE_
<img width="622" alt="Screenshot 2024-12-30 at 15 39 21" src="https://github.com/user-attachments/assets/fef13a8c-2bf0-4ced-8cfd-e8d24b8187a8" />

_AFTER_
<img width="635" alt="Screenshot 2024-12-30 at 15 38 09" src="https://github.com/user-attachments/assets/903db20c-103a-490b-91f0-20f6ccaa651e" />

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
