### PR TITLE
fix: displaying json example when showObjectSchemaExamples enabled

### DIFF
--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -393,7 +393,7 @@ export function getSerializedValue(field: FieldModel, example: any) {
     // decode for better readability in examples: see https://github.com/Redocly/redoc/issues/1138
     return decodeURIComponent(serializeParameterValue(field, example));
   } else {
-    return String(example);
+    return typeof example === 'object' ? example : String(example);
   }
 }
 


### PR DESCRIPTION
## What/Why/How?
when you use `showObjectSchemaExamples` and the example is an Object it displays `Example: [object Object]`. That Pr fix it
## Reference
fixes: https://github.com/Redocly/redoc/issues/2610
## Tests

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
