### PR TITLE
fix: Uniqueness of group ID when special characters exist in tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "mark.js": "^8.11.1",
     "marked": "^4.3.0",
     "mobx-react": "^9.1.1",
+    "nanoid": "^5.1.2",
     "openapi-sampler": "^1.5.0",
     "path-browserify": "^1.0.1",
     "perfect-scrollbar": "^1.5.5",

--- a/src/services/models/Group.model.ts
+++ b/src/services/models/Group.model.ts
@@ -1,4 +1,5 @@
 import { action, observable, makeObservable } from 'mobx';
+import { nanoid } from 'nanoid';
 
 import type { OpenAPIExternalDocumentation, OpenAPITag } from '../../types';
 import { safeSlugify } from '../../utils';
@@ -37,8 +38,11 @@ export class GroupModel implements IMenuItem {
   ) {
     makeObservable(this);
 
+    const safeGroupName = safeSlugify(tagOrGroup.name);
+    const groupId = [type, '/', safeGroupName, `_${nanoid(8)}`].join('');
+
     // markdown headings already have ids calculated as they are needed for heading anchors
-    this.id = (tagOrGroup as MarkdownHeading).id || type + '/' + safeSlugify(tagOrGroup.name);
+    this.id = (tagOrGroup as MarkdownHeading).id || groupId;
     this.type = type;
     this.name = tagOrGroup['x-displayName'] || tagOrGroup.name;
     this.level = (tagOrGroup as MarkdownHeading).level || 1;


### PR DESCRIPTION
## What/Why/How?
Uniqueness of group ID when special characters exist in tags
```yaml
...
      tags:
        - (RFC2544)配置管理
...
      tags:
        - (RFC2544)依赖管理
...
```
When the above content appears in the tags of OpenAPI, the safeSlugify function will replace them with the same content `(RFC2544)`.
This will result in different content generating the same ID.

## Reference
null

## Tests
Add an API with the above tags content in museum.yaml, and click the left menu to check if it can expand properly.

## Screenshots (optional)
null

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
