### PR TITLE
added support for specifying target in x-logo href

### DIFF
--- a/docs/redoc-vendor-extensions.md
+++ b/docs/redoc-vendor-extensions.md
@@ -120,12 +120,13 @@ Extends the OpenAPI [Info Object](https://redocly.com/docs/openapi-visual-refere
 The information about API logo
 
 #### Fixed fields
-| Field Name      | Type    | Description |
-| :-------------- | :------: | :---------- |
+| Field Name      | Type    | Description                                                                                                                                        |
+| :-------------- | :------: |:---------------------------------------------------------------------------------------------------------------------------------------------------|
 | url             | string   | The URL pointing to the spec logo. MUST be in the format of a URL. It SHOULD be an absolute URL so your API definition is usable from any location |
-| backgroundColor | string   | background color to be used. MUST be RGB color in [hexadecimal format] (https://en.wikipedia.org/wiki/Web_colors#Hex_triplet) |
-| altText        | string   | Text to use for alt tag on the logo. Defaults to 'logo' if nothing is provided. |
-| href        | string   | The URL pointing to the contact page. Default to 'info.contact.url' field of the OAS. |
+| backgroundColor | string   | background color to be used. MUST be RGB color in [hexadecimal format] (https://en.wikipedia.org/wiki/Web_colors#Hex_triplet)                      |
+| altText        | string   | Text to use for alt tag on the logo. Defaults to 'logo' if nothing is provided.                                                                    |
+| href        | string   | The URL pointing to the contact page. Default to 'info.contact.url' field of the OAS.                                                              |
+| hrefTarget        | string   | The target of the generated anchor tag.                                                                                               |
 
 
 #### x-logo example

--- a/src/components/ApiLogo/ApiLogo.tsx
+++ b/src/components/ApiLogo/ApiLogo.tsx
@@ -13,6 +13,7 @@ export class ApiLogo extends React.Component<{ info: OpenAPIInfo }> {
     }
 
     const logoHref = logoInfo.href || (info.contact && info.contact.url);
+    const logoHrefTarget = logoInfo.hrefTarget;
 
     // Use the english word logo if no alt text is provided
     const altText = logoInfo.altText ? logoInfo.altText : 'logo';
@@ -20,7 +21,7 @@ export class ApiLogo extends React.Component<{ info: OpenAPIInfo }> {
     const logo = <LogoImgEl src={logoInfo.url} alt={altText} />;
     return (
       <LogoWrap style={{ backgroundColor: logoInfo.backgroundColor }}>
-        {logoHref ? LinkWrap(logoHref)(logo) : logo}
+        {logoHref ? LinkWrap({ url: logoHref, target: logoHrefTarget })(logo) : logo}
       </LogoWrap>
     );
   }

--- a/src/components/ApiLogo/styled.elements.tsx
+++ b/src/components/ApiLogo/styled.elements.tsx
@@ -17,5 +17,12 @@ const Link = styled.a`
   display: inline-block;
 `;
 
-// eslint-disable-next-line react/display-name
-export const LinkWrap = url => Component => <Link href={url}>{Component}</Link>;
+export const LinkWrap =
+  ({ url, target }) =>
+  // eslint-disable-next-line react/display-name
+  Component =>
+    (
+      <Link href={url} target={target}>
+        {Component}
+      </Link>
+    );


### PR DESCRIPTION
## What/Why/How?
This solves the use case of adding target attribute to the generated anchor tag in logo

## Reference

## Tests

## Screenshots (optional)

## Check yourself

- [X] Code is linted
- [X] Tested
- [ ] All new/updated code is covered with tests
