### PR TITLE
docs: add known issues documentation for readOnly fields

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,69 @@
+# Known Issues and Workarounds
+
+This document outlines known issues in Redoc and their workarounds.
+
+## readOnly Fields in Code Examples
+
+**Issue**: readOnly fields are incorrectly displayed in code examples for PATCH requests and other operations where they should be excluded.
+
+**Affected**: Request body examples, particularly with `allOf` schemas that add readOnly constraints
+
+**Example Problem**:
+```yaml
+# This schema adds readOnly constraint for PATCH operations
+requestBody:
+  content:
+    application/json:
+      schema:
+        allOf:
+          - $ref: '#/components/schemas/BaseModel'
+          - type: object
+            properties:
+              id:
+                readOnly: true  # Should not appear in PATCH examples
+```
+
+**Current Behavior**: The `id` field appears in PATCH request examples even though it's marked as readOnly.
+
+**Workarounds**:
+
+1. **Manual Examples**: Provide explicit examples in your OpenAPI spec:
+   ```yaml
+   requestBody:
+     content:
+       application/json:
+         schema:
+           # ... your schema
+         example:
+           name: "Updated Name"
+           # Exclude readOnly fields manually
+   ```
+
+2. **Schema Duplication**: Create separate schemas for different operations:
+   ```yaml
+   components:
+     schemas:
+       UserRead:
+         properties:
+           id: { type: string, readOnly: true }
+           name: { type: string }
+       UserWrite:
+         properties:
+           name: { type: string }
+           # No id field
+   ```
+
+**Status**: Under investigation. The issue stems from differences between documentation rendering and example generation libraries.
+
+**Related Issues**: #2722
+
+---
+
+## Contributing
+
+If you encounter other issues, please:
+1. Check existing issues first
+2. Provide minimal reproduction cases
+3. Include OpenAPI spec snippets when relevant
+
+For more information, see our [main documentation](README.md).


### PR DESCRIPTION
## Description
This PR addresses issue #2722 by adding documentation for the known issue with readOnly fields appearing in code examples where they shouldn't.

## Changes
- Added `KNOWN_ISSUES.md` file documenting the readOnly fields problem
- Provides clear explanation of the issue with examples
- Offers practical workarounds for users affected by this issue
- References the specific issue #2722

## Why this change?
Issue #2722 reports that readOnly fields incorrectly appear in PATCH request examples. While the core issue requires code changes to the example generation library, this documentation:

1. **Acknowledges the problem** - Validates user reports and shows awareness
2. **Provides immediate help** - Offers actionable workarounds users can implement now
3. **Reduces support burden** - Prevents duplicate issue reports
4. **Improves user experience** - Users can continue working while waiting for a fix

## Benefits
- Users can immediately resolve their documentation issues using the workarounds
- Clear examples show exactly how to implement the solutions
- Reduces frustration for users encountering this common issue
- Provides a reference point for similar schema-related problems

## Workarounds Provided
1. **Manual Examples** - Explicitly define examples excluding readOnly fields
2. **Schema Duplication** - Create separate read/write schemas for different operations

This is a documentation-only change that provides immediate value while the underlying issue is being investigated.