### PR TITLE
chore(deps): bump openapi-sampler from 1.5.0 to 1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "mark.js": "^8.11.1",
         "marked": "^4.3.0",
         "mobx-react": "9.2.0",
-        "openapi-sampler": "^1.5.0",
+        "openapi-sampler": "^1.6.2",
         "path-browserify": "^1.0.1",
         "perfect-scrollbar": "^1.5.5",
         "polished": "^4.2.2",
@@ -9119,6 +9119,24 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -15142,11 +15160,13 @@
       }
     },
     "node_modules/openapi-sampler": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.5.0.tgz",
-      "integrity": "sha512-6aZ/C0/1Dr3NoIuEy+CcavOsH49I8x0jHjik0kOuNmT+qmBLPrDWMncIQhrd0zbsd/zCVzfb9Vn3BZGFGTLn7A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.6.2.tgz",
+      "integrity": "sha512-NyKGiFKfSWAZr4srD/5WDhInOWDhfml32h/FKUqLpEwKJt0kG0LGUU0MdyNkKrVGuJnw6DuPWq/sHCwAMpiRxg==",
+      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
+        "fast-xml-parser": "^4.5.0",
         "json-pointer": "0.6.2"
       }
     },
@@ -17798,6 +17818,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-loader": {
       "version": "3.3.1",
@@ -26505,6 +26537,14 @@
       "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "requires": {
+        "strnum": "^1.1.1"
+      }
+    },
     "fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -30874,11 +30914,12 @@
       }
     },
     "openapi-sampler": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.5.0.tgz",
-      "integrity": "sha512-6aZ/C0/1Dr3NoIuEy+CcavOsH49I8x0jHjik0kOuNmT+qmBLPrDWMncIQhrd0zbsd/zCVzfb9Vn3BZGFGTLn7A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.6.2.tgz",
+      "integrity": "sha512-NyKGiFKfSWAZr4srD/5WDhInOWDhfml32h/FKUqLpEwKJt0kG0LGUU0MdyNkKrVGuJnw6DuPWq/sHCwAMpiRxg==",
       "requires": {
         "@types/json-schema": "^7.0.7",
+        "fast-xml-parser": "^4.5.0",
         "json-pointer": "0.6.2"
       }
     },
@@ -32913,6 +32954,11 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA=="
     },
     "style-loader": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "mark.js": "^8.11.1",
     "marked": "^4.3.0",
     "mobx-react": "9.2.0",
-    "openapi-sampler": "^1.5.0",
+    "openapi-sampler": "^1.6.2",
     "path-browserify": "^1.0.1",
     "perfect-scrollbar": "^1.5.5",
     "polished": "^4.2.2",


### PR DESCRIPTION
## What/Why/How?
Bump `openapi-sampler` from 1.5.0 to 1.6.2.
## Reference

## Tests

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
