### PR TITLE
chore: v2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [2.5.2](https://github.com/Redocly/redoc/compare/v2.5.1...v2.5.2) (2025-10-15)
+
+
+### Bug Fixes
+
+* Bumped `openapi-sampler` dependency to include the fix for `readOnly`/`writeOnly` handling in allOf.
+
+
 # [2.5.1](https://github.com/Redocly/redoc/compare/v2.4.0...v2.5.1) (2025-09-26)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "redoc",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redoc",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redoc",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "ReDoc",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What/Why/How?
Release OSS Redoc v2.5.2:

### Bug Fixes

* Bumped `openapi-sampler` dependency to include the fix for `readOnly`/`writeOnly` handling in allOf. [ #2732](https://github.com/Redocly/redoc/pull/2732)

## Reference

## Tests

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
