### PR TITLE
Change Authorizations header to h3 (use UnderlinedHeaderAuth)

### DIFF
--- a/src/common-elements/headers.ts
+++ b/src/common-elements/headers.ts
@@ -52,3 +52,15 @@ export const UnderlinedHeader = styled.h5`
 
   ${extensionsHook('UnderlinedHeader')};
 `;
+
+export const UnderlinedHeaderAuth = styled.h3`
+  border-bottom: 1px solid rgba(38, 50, 56, 0.3);
+  margin: 1em 0 1em 0;
+  color: rgba(38, 50, 56, 0.5);
+  font-weight: normal;
+  text-transform: uppercase;
+  font-size: 0.929em;
+  line-height: 20px;
+
+  ${extensionsHook('UnderlinedHeaderAuth')};
+`;

--- a/src/components/SecurityRequirement/styled.elements.ts
+++ b/src/components/SecurityRequirement/styled.elements.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { linksCss } from '../Markdown/styled.elements';
 import { media } from '../../styled-components';
-import { UnderlinedHeader } from '../../common-elements';
+import { UnderlinedHeaderAuth } from '../../common-elements';
 
 export const Header = styled.div`
   background-color: #e4e7eb;
@@ -93,7 +93,7 @@ export const SecuritiesColumn = styled.div<{ $expanded?: boolean }>`
   `}
 `;
 
-export const AuthHeader = styled(UnderlinedHeader)`
+export const AuthHeader = styled(UnderlinedHeaderAuth)`
   display: inline-block;
   margin: 0;
 `;


### PR DESCRIPTION
## What/Why/How?
Change the "Authorizations:" header from an `h5` to an `h3` to restore correct heading hierarchy inside operation details.

Why:
- Operation title uses `h2`, `Authorizations:` was `h5` and other sections used `h3` which breaks semantic heading order.
- Fixes accessibility and document outline for screen readers and improves SEO.

What changed:
- Render `Authorizations:` with an `h3`-styled header (`UnderlinedHeaderAuth`) instead of an `h5`.
- Ensure visual styles (underlined, uppercase) remain identical to prior appearance.

How:
- Replace `AuthHeader` to use `UnderlinedHeaderAuth` in:
  - `src/components/SecurityRequirement/styled.elements.ts`
- `UnderlinedHeaderAuth` is defined in `src/common-elements/headers.ts` as an `h3`-based styled component.


## Reference

- Fixes / references issue: https://github.com/Redocly/redoc/issues/2741

## Tests

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
