### PR TITLE
chore: Restore correct output directory for transpiled files output

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,7 +57,7 @@ export default defineConfig(({ command, mode }) => {
       global: 'globalThis',
     },
     build: {
-      outDir: 'bundle',
+      outDir: 'bundles',
       emptyOutDir: false,
       lib: {
         entry: resolve(__dirname, isStandalone ? 'src/standalone.tsx' : 'src/index.ts'),


### PR DESCRIPTION
The previous change incorrectly modified the output/dist path in the build configuration, causing compiled files to be emitted to the wrong location.

This commit restores the proper outdir directory so that transpiled/built files are generated in the expected folder again.