### PR TITLE
Stop removing templates on init as it provokes a failure on restart

### DIFF
--- a/config/docker/docker-entrypoint.d/95-clean-up.sh
+++ b/config/docker/docker-entrypoint.d/95-clean-up.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# remove template files
-rm -f /usr/share/nginx/html/index.prefix.tpl.html /usr/share/nginx/html/index.tpl.html
-
 if [ -n "$BASE_PATH" ]; then
   rm -f /etc/nginx/conf.d/default.conf
   rm -f /usr/share/nginx/html/index.html


### PR DESCRIPTION
## What/Why/How?

If the templates are removed the first time the container is started, it fails whenever it is restarted:
<img width="1845" height="928" alt="image" src="https://github.com/user-attachments/assets/696f11a9-c8a6-4102-ba1a-2810befa3748" />

There is another option, which is to check existence before performing the template substitution, I can do that if it's preferable.

## Check yourself

- [ ] Code is linted (N/A)
- [X] Tested
- [ ] All new/updated code is covered with tests (N/A)
