### PR TITLE
feat: Show items descriptions in oneOf components

### DIFF
--- a/src/components/Schema/OneOfSchema.tsx
+++ b/src/components/Schema/OneOfSchema.tsx
@@ -62,7 +62,7 @@ export class OneOfSchema extends React.Component<SchemaProps> {
         <div>
           {oneOf[schema.activeOneOf].deprecated && <Badge type="warning">Deprecated</Badge>}
         </div>
-        {activeSchema.rawSchema.description && (
+        {activeSchema.type == 'object' && activeSchema.rawSchema.description && (
           <Markdown source={activeSchema.rawSchema.description} />
         )}
         <ConstraintsView constraints={activeSchema.constraints} />

--- a/src/components/Schema/OneOfSchema.tsx
+++ b/src/components/Schema/OneOfSchema.tsx
@@ -7,6 +7,7 @@ import {
   OneOfList,
 } from '../../common-elements/schema';
 import { Badge } from '../../common-elements/shelfs';
+import { Markdown } from '../Markdown/Markdown';
 import { SchemaModel } from '../../services/models';
 import { ConstraintsView } from '../Fields/FieldConstraints';
 import { Schema, SchemaProps } from './Schema';
@@ -61,6 +62,9 @@ export class OneOfSchema extends React.Component<SchemaProps> {
         <div>
           {oneOf[schema.activeOneOf].deprecated && <Badge type="warning">Deprecated</Badge>}
         </div>
+        {activeSchema.rawSchema.description && (
+          <Markdown source={activeSchema.rawSchema.description} />
+        )}
         <ConstraintsView constraints={activeSchema.constraints} />
         <Schema {...this.props} schema={activeSchema} />
       </div>


### PR DESCRIPTION
## What/Why/How?

Bsaically this allows users to set description in object schemas that are insode oneOf schemas and show it to the user.

I consider this a WIP for now since I'm not sure the way I'm doing it is the best approach.

What I tried to do first was to use directly `activeSchema.description`, but I noticed that when the schema doesn't have a description defined, it will have the description of the oneOf schema instead. I'm not sure if that is by design, a bug, or something that needs some other change to work.

The solution was to use `activeSchema.rawSchema.description` since that one will contain the correct description.

## Tests

I didn't add any new test, the existing ones are passing just fine.

## Screenshots (optional)

<img width="1052" height="1219" alt="image" src="https://github.com/user-attachments/assets/958874d4-af38-4342-bbc6-22afdb4dc014" />

## Check yourself

- [x] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests
