### PR TITLE
chore: v2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# [2.5.2](https://github.com/Redocly/redoc/compare/v2.5.1...v2.5.2) (2025-10-15)
+## [2.5.3](https://github.com/Redocly/redoc/compare/v2.5.1...v2.5.3) (2026-05-27)
+
+
+### Bug fixes
+
+* Fix vulnerabilities and prevent crash in openapi 3.2
 
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "redoc",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redoc",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^1.34.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redoc",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "ReDoc",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What/Why/How?
Release OSS Redoc v2.5.3:
- Fix vulnerabilities and prevent crash in openapi 3.2
## Reference

## Tests

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
