### PR TITLE
hotfix: change link into workerize-loader to fix publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.4",
         "webpack-node-externals": "^3.0.0",
-        "workerize-loader": "github:redocly/workerize-loader#webpack-5-dist"
+        "workerize-loader": "git+https://github.com/Redocly/workerize-loader.git#webpack-5-dist"
       },
       "engines": {
         "node": ">=6.9",
@@ -20568,7 +20568,7 @@
     },
     "node_modules/workerize-loader": {
       "version": "1.3.0",
-      "resolved": "git+https://git@github.com/redocly/workerize-loader.git#6897b3fa5784c8f4970c81e04dbc8025f3c60938",
+      "resolved": "git+ssh://git@github.com/Redocly/workerize-loader.git#6897b3fa5784c8f4970c81e04dbc8025f3c60938",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -35329,9 +35329,9 @@
       "dev": true
     },
     "workerize-loader": {
-      "version": "git+https://git@github.com/redocly/workerize-loader.git#6897b3fa5784c8f4970c81e04dbc8025f3c60938",
+      "version": "git+ssh://git@github.com/Redocly/workerize-loader.git#6897b3fa5784c8f4970c81e04dbc8025f3c60938",
       "dev": true,
-      "from": "workerize-loader@github:redocly/workerize-loader#webpack-5-dist",
+      "from": "workerize-loader@git+https://github.com/Redocly/workerize-loader.git#webpack-5-dist",
       "requires": {
         "loader-utils": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
     "webpack-node-externals": "^3.0.0",
-    "workerize-loader": "github:redocly/workerize-loader#webpack-5-dist"
+    "workerize-loader": "git+https://github.com/Redocly/workerize-loader.git#webpack-5-dist"
   },
   "peerDependencies": {
     "core-js": "^3.1.4",


### PR DESCRIPTION
## What/Why/How?
The last publishing has failed 
https://github.com/Redocly/redoc/actions/runs/26517067663/job/78098007033

This should fix the problem
## Reference

## Tests

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
