### PR TITLE
chore: use npm for workerize-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       "devDependencies": {
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@cypress/webpack-preprocessor": "^7.1.0",
-        "@redocly/workerize-loader": "^1.3.0",
+        "@redocly/workerize-loader": "^1.3.1",
         "@size-limit/file": "^11.1.4",
         "@types/chai": "^4.2.18",
         "@types/dompurify": "^2.2.2",
@@ -4320,9 +4320,9 @@
       }
     },
     "node_modules/@redocly/workerize-loader": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@redocly/workerize-loader/-/workerize-loader-1.3.0.tgz",
-      "integrity": "sha512-Vp0bHVaOvnEOY2LWRGKsG1TJWbmcs4zE1F3rbm98CMFsZv00xX5c34EvKVW70y4PzUxrw9OhX5zs/itvUkLcTQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@redocly/workerize-loader/-/workerize-loader-1.3.1.tgz",
+      "integrity": "sha512-WVzDeBhmzzfRT6IIz2nKD6p80wHNupi+hVVvYZCTAzYsYDui+39AxhyrF8n7UeCLwZU3On4tQx+d6d6bgG4CIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23546,9 +23546,9 @@
       }
     },
     "@redocly/workerize-loader": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@redocly/workerize-loader/-/workerize-loader-1.3.0.tgz",
-      "integrity": "sha512-Vp0bHVaOvnEOY2LWRGKsG1TJWbmcs4zE1F3rbm98CMFsZv00xX5c34EvKVW70y4PzUxrw9OhX5zs/itvUkLcTQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@redocly/workerize-loader/-/workerize-loader-1.3.1.tgz",
+      "integrity": "sha512-WVzDeBhmzzfRT6IIz2nKD6p80wHNupi+hVVvYZCTAzYsYDui+39AxhyrF8n7UeCLwZU3On4tQx+d6d6bgG4CIw==",
       "dev": true,
       "requires": {
         "loader-utils": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
       "devDependencies": {
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@cypress/webpack-preprocessor": "^7.1.0",
+        "@redocly/workerize-loader": "^1.3.0",
         "@size-limit/file": "^11.1.4",
         "@types/chai": "^4.2.18",
         "@types/dompurify": "^2.2.2",
@@ -98,8 +99,7 @@
         "webpack": "^5.94.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.4",
-        "webpack-node-externals": "^3.0.0",
-        "workerize-loader": "github:redocly/workerize-loader#webpack-5-dist"
+        "webpack-node-externals": "^3.0.0"
       },
       "engines": {
         "node": ">=6.9",
@@ -4317,6 +4317,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@redocly/workerize-loader": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@redocly/workerize-loader/-/workerize-loader-1.3.0.tgz",
+      "integrity": "sha512-Vp0bHVaOvnEOY2LWRGKsG1TJWbmcs4zE1F3rbm98CMFsZv00xX5c34EvKVW70y4PzUxrw9OhX5zs/itvUkLcTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^2.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "*"
       }
     },
     "node_modules/@simple-libs/child-process-utils": {
@@ -20566,18 +20579,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/workerize-loader": {
-      "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/redocly/workerize-loader.git#6897b3fa5784c8f4970c81e04dbc8025f3c60938",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^2.0.0"
-      },
-      "peerDependencies": {
-        "webpack": "*"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -23542,6 +23543,15 @@
             "brace-expansion": "^2.0.1"
           }
         }
+      }
+    },
+    "@redocly/workerize-loader": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@redocly/workerize-loader/-/workerize-loader-1.3.0.tgz",
+      "integrity": "sha512-Vp0bHVaOvnEOY2LWRGKsG1TJWbmcs4zE1F3rbm98CMFsZv00xX5c34EvKVW70y4PzUxrw9OhX5zs/itvUkLcTQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0"
       }
     },
     "@simple-libs/child-process-utils": {
@@ -35327,14 +35337,6 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
-    },
-    "workerize-loader": {
-      "version": "git+ssh://git@github.com/redocly/workerize-loader.git#6897b3fa5784c8f4970c81e04dbc8025f3c60938",
-      "dev": true,
-      "from": "workerize-loader@github:redocly/workerize-loader#webpack-5-dist",
-      "requires": {
-        "loader-utils": "^2.0.0"
-      }
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@cfaester/enzyme-adapter-react-18": "^0.8.0",
     "@cypress/webpack-preprocessor": "^7.1.0",
+    "@redocly/workerize-loader": "^1.3.0",
     "@size-limit/file": "^11.1.4",
     "@types/chai": "^4.2.18",
     "@types/dompurify": "^2.2.2",
@@ -127,8 +128,7 @@
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4",
-    "webpack-node-externals": "^3.0.0",
-    "workerize-loader": "github:redocly/workerize-loader#webpack-5-dist"
+    "webpack-node-externals": "^3.0.0"
   },
   "peerDependencies": {
     "core-js": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@cfaester/enzyme-adapter-react-18": "^0.8.0",
     "@cypress/webpack-preprocessor": "^7.1.0",
-    "@redocly/workerize-loader": "^1.3.0",
+    "@redocly/workerize-loader": "^1.3.1",
     "@size-limit/file": "^11.1.4",
     "@types/chai": "^4.2.18",
     "@types/dompurify": "^2.2.2",

--- a/src/services/SearchStore.ts
+++ b/src/services/SearchStore.ts
@@ -9,7 +9,7 @@ function getWorker() {
   if (IS_BROWSER) {
     try {
       // tslint:disable-next-line
-      worker = require('workerize-loader?inline&fallback=false!./SearchWorker.worker');
+      worker = require('@redocly/workerize-loader?inline&fallback=false!./SearchWorker.worker');
     } catch (e) {
       worker = require('./SearchWorker.worker').default;
     }


### PR DESCRIPTION
## What/Why/How?
Use npm instead for link for workerize-loader
## Reference

## Tests

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
