### PR TITLE
chore: update node version for publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,12 +68,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: write
-      packages: read
+      contents: read
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '14.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - uses: actions/checkout@v3
       - name: Download bundled artifacts


### PR DESCRIPTION
## What/Why/How?
In previous steps, we fixed an issue with `workerize-loader`. Now time to update the node version in the publish action to support OIDC handshake. It should unblock publishing process
## Reference

## Tests

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested
- [x] All new/updated code is covered with tests
