### PR TITLE
chore: add npm token to unblock publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,6 +92,8 @@ jobs:
         run: npm ci && npm run declarations
       - name: Publish to NPM
         run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-cdn:
     name: Publish to CDN


### PR DESCRIPTION
## What/Why/How?
add npm token to avoid error
`The requested resource 'redoc@2.5.3' could not be found or you do not have permission to access it.`
## Reference

## Tests

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested
- [x] All new/updated code is covered with tests
