### PR TITLE
chore: rename npm publish action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,8 +92,6 @@ jobs:
         run: npm ci && npm run declarations
       - name: Publish to NPM
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-cdn:
     name: Publish to CDN


### PR DESCRIPTION
## What/Why/How?
Rename the GitHub action to publish `redoc` package to npm and unify it with the feature version of `Redoc CE 3.0`(in progress).
## Reference

## Tests

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
