### PR TITLE
Fix custom download URL filenames

### DIFF
--- a/src/services/__tests__/models/ApiInfo.test.ts
+++ b/src/services/__tests__/models/ApiInfo.test.ts
@@ -130,7 +130,7 @@ describe('Models', () => {
       expect(info.downloadFileName).toEqual('test.yaml');
     });
 
-    test('should correctly populate download link', () => {
+    test('should correctly populate custom download link without forcing a file name', () => {
       parser.spec = {
         openapi: '3.0.0',
         info: {
@@ -150,7 +150,7 @@ describe('Models', () => {
           },
         ]
       `);
-      expect(info.downloadFileName).toMatchInlineSnapshot(`"openapi.json"`);
+      expect(info.downloadFileName).toMatchInlineSnapshot(`undefined`);
     });
 
     test('should correctly populate download link and download file name', () => {
@@ -188,7 +188,7 @@ describe('Models', () => {
           },
         ]
       `);
-      expect(info2.downloadFileName).toMatchInlineSnapshot(`"openapi.json"`);
+      expect(info2.downloadFileName).toMatchInlineSnapshot(`undefined`);
     });
   });
 });

--- a/src/services/models/ApiInfo.ts
+++ b/src/services/models/ApiInfo.ts
@@ -70,9 +70,12 @@ export class ApiInfoModel implements OpenAPIInfo {
   }
 
   private getDownloadFileName(): string | undefined {
-    if (!this.parser.specUrl && !this.options.downloadDefinitionUrl) {
-      return this.options.downloadFileName || 'openapi.json';
+    if (this.options.downloadFileName) {
+      return this.options.downloadFileName;
     }
-    return this.options.downloadFileName;
+
+    if (!this.parser.specUrl && !this.options.downloadDefinitionUrl && !this.options.downloadUrls) {
+      return 'openapi.json';
+    }
   }
 }


### PR DESCRIPTION
## What/Why/How?

Custom `downloadUrls` without an explicit `downloadFileName` currently inherit the generated-spec fallback filename (`openapi.json`). This forces YAML or other custom download URLs to save as `openapi.json`.

This change only applies the `openapi.json` fallback when Redoc generates the downloadable spec itself. Custom `downloadUrls` now leave the filename unset unless `downloadFileName` is explicitly configured, so the browser can use the URL/content-disposition filename.

## Reference

Fixes #2787

## Tests

- `npx jest src/services/__tests__/models/ApiInfo.test.ts --runInBand --coverage=false`
- `npm run ts-check`
- `npx eslint src/services/models/ApiInfo.ts src/services/__tests__/models/ApiInfo.test.ts --no-cache`
- `npx prettier --check src/services/models/ApiInfo.ts src/services/__tests__/models/ApiInfo.test.ts`
- `git diff --check`

## Screenshots (optional)

N/A

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests
