### PR TITLE
fix(search): drop stray braces that break search results box styles

### DIFF
--- a/src/components/SearchBox/styled.elements.tsx
+++ b/src/components/SearchBox/styled.elements.tsx
@@ -57,16 +57,16 @@ export const SearchIcon = styled((props: { className?: string }) => (
 
 export const SearchResultsBox = styled.div`
   padding: ${props => props.theme.spacing.unit}px 0;
-  background-color: ${({ theme }) => darken(0.05, theme.sidebar.backgroundColor)}};
+  background-color: ${({ theme }) => darken(0.05, theme.sidebar.backgroundColor)};
   color: ${props => props.theme.sidebar.textColor};
   min-height: 150px;
   max-height: 250px;
-  border-top: ${({ theme }) => darken(0.1, theme.sidebar.backgroundColor)}};
-  border-bottom: ${({ theme }) => darken(0.1, theme.sidebar.backgroundColor)}};
+  border-top: ${({ theme }) => darken(0.1, theme.sidebar.backgroundColor)};
+  border-bottom: ${({ theme }) => darken(0.1, theme.sidebar.backgroundColor)};
   margin-top: 10px;
   line-height: 1.4;
   font-size: 0.9em;
-  
+
   li {
     background-color: inherit;
   }


### PR DESCRIPTION
## What/Why/How?

`SearchResultsBox` in `src/components/SearchBox/styled.elements.tsx` has an extra `}` after three interpolations (`background-color`, `border-top`, `border-bottom`):

```js
background-color: ${({ theme }) => darken(0.05, theme.sidebar.backgroundColor)}};
```

With **styled-components v6 (stylis 4)** the first stray brace closes the rule early, so everything after `background-color` is emitted *outside* the class rule and dropped by the browser:

```
// broken (current main)
.GvrvM{padding:5px 0;background-color:#f2f2f2;}
color:#333;
min-height:150px;
max-height:250px;
margin-top:10px;
line-height:1.4;
font-size:0.9em;

// after this PR
.kuYQEX{padding:5px 0;background-color:#f2f2f2;color:#333;min-height:150px;max-height:250px;margin-top:10px;line-height:1.4;font-size:0.9em;}
```

styled-components v5 (stylis 3.5) happens to tolerate the stray brace, which is why this is invisible in the bundled demo but breaks consumers that supply styled-components v6 — and v6 is an allowed peer range (`^4.1.1 || ^5.1.1 || ^6.0.5`).

The user-visible symptom is that **the search results are not scrollable and no scrollbar appears**. Because `max-height: 250px` is lost, the results box grows to the full result list height (measured 5838px for a 79-result query), so its perfect-scrollbar container has `clientHeight === scrollHeight`, PS keeps `.ps__rail-y` at `display: none`, and the sidebar (`overflow: hidden`) clips everything below the viewport. Results exist but are unreachable. `color`, `margin-top`, `line-height`, `font-size`, `li { background-color: inherit }` and the compact `MenuItemLabel` padding are lost too, so result rows also render oversized.

Fix: remove the three stray `}`. The change is whitespace-only in effect on the source, but restores all of the intended declarations.

Note: `border-top`/`border-bottom` only specify a colour, so with `border-style` defaulting to `none` they still paint nothing — same as today's behaviour. I kept the diff minimal instead of guessing `1px solid`; happy to add it if that was the original intent (it was `border-top: 1px solid #e1e1e1` before 1bf490c).

## Reference

Introduced in 1bf490c05b343d262f8819bf1ddc433e070be1b9 (`fix: search-box use theme`, first released in v2.0.0-rc.19); a0bd27c later renamed `theme.menu.*` to `theme.sidebar.*` and kept the typo.

Reported downstream (redocusaurus / Docusaurus 3, which uses styled-components 6): https://gitea.com/gitea/docs/issues/257

## Tests

- Reproduced the stylis-4 truncation with a minimal styled-components 6.1.17 + `ServerStyleSheet` snippet (output above); the same snippet on styled-components 5 shows the brace being tolerated.
- Verified against a real redoc-rendered site (docs.gitea.com API reference, redoc 2.4.0 via redocusaurus): before, results box = 5838px, container `scrollHeight === clientHeight`, no `ps--active-y`, `.ps__rail-y` `display: none`, scrolling impossible. After applying the missing declarations: box = 250px, `scrollHeight` 3674px, `ps--active-y` set, rail visible, scrolling works.
- `e2e/integration/search.e2e.ts` keeps passing on selectors (`[data-role="search:results"]`), unchanged.

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests
