### PR TITLE
chore: v2.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
-## [2.5.3](https://github.com/Redocly/redoc/compare/v2.5.1...v2.5.3) (2026-05-27)
+# [2.5.4](https://github.com/Redocly/redoc/compare/v2.5.3...v2.5.4) (2026-09-10)
+
+### Bug Fixes
+
+* Fix accessibility errors reported by pa11y ([#2837](https://github.com/Redocly/redoc/issues/2837)) ([1424bfd](https://github.com/Redocly/redoc/commit/1424bfd0100488a83f462f7047ae7372e2d10c9f))
+* Resolve js-yaml, fast-uri and brace-expansion vulnerabilities ([#2832](https://github.com/Redocly/redoc/issues/2832)) ([6188dc4](https://github.com/Redocly/redoc/commit/6188dc4a1c689de2ed3bdfb6061076d0a73bb949))
+* Bump dompurify from 3.4.6 to 3.4.13 ([#2824](https://github.com/Redocly/redoc/issues/2824)) ([616398b](https://github.com/Redocly/redoc/commit/616398b62bbd11dc5edad173c4520b754325b0bb))
 
 
-### Bug fixes
-
-* Fix vulnerabilities and prevent crash in openapi 3.2
+# [2.5.3](https://github.com/Redocly/redoc/compare/v2.5.1...v2.5.3) (2026-05-27)
 
 
 ### Bug Fixes
 
+* Fix vulnerabilities and prevent crash in openapi 3.2
 * Bumped `openapi-sampler` dependency to include the fix for `readOnly`/`writeOnly` handling in allOf.
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "redoc",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redoc",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^1.34.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redoc",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "ReDoc",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What/Why/How?
Release OSS Redoc v2.5.4:
### Bug Fixes

* Fix accessibility errors reported by pa11y ([#2837](https://github.com/Redocly/redoc/issues/2837)) ([1424bfd](https://github.com/Redocly/redoc/commit/1424bfd0100488a83f462f7047ae7372e2d10c9f))
* Resolve js-yaml, fast-uri and brace-expansion vulnerabilities ([#2832](https://github.com/Redocly/redoc/issues/2832)) ([6188dc4](https://github.com/Redocly/redoc/commit/6188dc4a1c689de2ed3bdfb6061076d0a73bb949))
* Bump dompurify from 3.4.6 to 3.4.13 ([#2824](https://github.com/Redocly/redoc/issues/2824)) ([616398b](https://github.com/Redocly/redoc/commit/616398b62bbd11dc5edad173c4520b754325b0bb))

## Reference

## Tests

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests